### PR TITLE
Added missing indices in InitializeAnalogInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ version.py
 .project
 .pydevproject
 
+#PyCharm Project files
+*.iml
+.idea/*
+.pycharmproject

--- a/hal-sim/hal_impl/functions.py
+++ b/hal-sim/hal_impl/functions.py
@@ -312,7 +312,7 @@ def checkAnalogOutputChannel(pin):
 def initializeAnalogInputPort(port, status):
     _checkAnalogIsFree(port)
     status.value = 0
-    hal_data['analog_in']['initialized'] = True
+    hal_data['analog_in'][port.pin]['initialized'] = True
     return types.AnalogPort(port)
 
 def checkAnalogModule(module):


### PR DESCRIPTION
I added a missing set of indices in initializeAnalogInput in hal-sim, fixing a TypeError whenever you used an AnalogInput device. I also added some patterns to .gitignore for git to ignore PyCharm's project files.

This is a re-do of #31, where I messed up the commit process.
