### PR TITLE
Added a missing __init__ with a missing argument to the Counter class

### DIFF
--- a/hal-sim/hal_impl/types.py
+++ b/hal-sim/hal_impl/types.py
@@ -99,7 +99,8 @@ class PWM:
 
 # opaque counter
 class Counter:
-    pass
+    def __init__(self, idx):
+        self.idx = idx
 
 # opaque encoder
 class Encoder:


### PR DESCRIPTION
This fixes a TypeError that occurred whenever a counter was initialized in the simulated HAL. A stub class in hal-sim/hal_impl/types.py was missing an `__init__`, which was supposed to accept an index for the counter.
