### PR TITLE
Don't throw errors when HAL emits a warning

### DIFF
--- a/hal-base/hal/functions.py
+++ b/hal-base/hal/functions.py
@@ -41,7 +41,7 @@ def _STATUSFUNC(name, restype, *params, out=None, library=_dll,
         elif status.value < 0:
             raise HALError(getHALErrorMessage(status.value))
         elif status.value > 0:
-            warnings.warn(getHALErrorMessage(status.value))
+            warnings.warn(getHALErrorMessage(status.value), stacklevel=2)
             return rv
     
     # Support introspection for API validation

--- a/hal-base/hal/functions.py
+++ b/hal-base/hal/functions.py
@@ -36,9 +36,13 @@ def _STATUSFUNC(name, restype, *params, out=None, library=_dll,
     def outer(*args, **kwargs):
         status = C.c_int32(0)
         rv = _inner(*args, status=status, **kwargs)
-        if status.value != 0:
+        if status.value == 0:
+            return rv
+        elif status.value < 0:
             raise HALError(getHALErrorMessage(status.value))
-        return rv
+        elif status.value > 0:
+            warnings.warn(getHALErrorMessage(status.value))
+            return rv
     
     # Support introspection for API validation
     if hasattr(_inner, 'fndata'):


### PR DESCRIPTION
- Fixes #143

To test this, you can do the following:

```
git clone https://github.com/robotpy/robotpy-wpilib.git
cd robotpy-wpilib
git checkout hal-warning
```

On a linux/OSX system, or if you have MSYS installed on windows, you can run `devtools/build_and_install.sh`. If you don't have either of those, post a comment and I can write something up that will get you going.