### PR TITLE
Set upSource and downSource properties to None if not in use.

### DIFF
--- a/wpilib/wpilib/counter.py
+++ b/wpilib/wpilib/counter.py
@@ -143,9 +143,13 @@ class Counter(SensorBase):
         #Set sources
         if upSource is not None:
             self.setUpSource(upSource)
+        else:
+            self.upSource = None
 
         if downSource is not None:
             self.setDownSource(downSource)
+        else:
+            self.downSource = None
 
         # when given two sources, set edges
         if upSource is not None and downSource is not None:


### PR DESCRIPTION
Otherwise we run into errors when we try to ```free()```