### PR TITLE
LiveWindow work: Fix DS thread crashing from exceptions thrown by LV device hooks.

### DIFF
--- a/wpilib/tests/conftest.py
+++ b/wpilib/tests/conftest.py
@@ -67,7 +67,13 @@ def wpilib(_module_patch, hal, hal_data):
     """Actual wpilib implementation"""
     import wpilib
     return wpilib
-    
+
+@pytest.fixture(scope="function")
+def networktables():
+    """Networktables instance"""
+    import networktables
+    networktables.NetworkTable.setTestMode()
+    return networktables
 
 #
 # Mock fixtures for testing things that don't have to interact with 

--- a/wpilib/tests/test_livewindow.py
+++ b/wpilib/tests/test_livewindow.py
@@ -1,0 +1,11 @@
+def test_livewindow_enabled(wpilib):
+    wpilib.LiveWindow.setEnabled(True)
+
+def test_livewindow_after_free(wpilib, networktables):
+    m = wpilib.Talon(0)
+    wpilib.LiveWindow.setEnabled(True)
+    wpilib.LiveWindow.run()
+    wpilib.LiveWindow.setEnabled(False)
+    m.free()
+    wpilib.LiveWindow.setEnabled(True)
+    wpilib.LiveWindow.run()

--- a/wpilib/wpilib/adxl345_i2c.py
+++ b/wpilib/wpilib/adxl345_i2c.py
@@ -61,6 +61,10 @@ class ADXL345_I2C(SensorBase):
 
         LiveWindow.addSensor("ADXL345_I2C", port, self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     # Accelerometer interface
 
     def setRange(self, range):

--- a/wpilib/wpilib/adxl345_spi.py
+++ b/wpilib/wpilib/adxl345_spi.py
@@ -71,6 +71,10 @@ class ADXL345_SPI(SensorBase):
 
         LiveWindow.addSensor("ADXL345_SPI", port, self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     # Accelerometer interface
 
     def setRange(self, range):

--- a/wpilib/wpilib/analogaccelerometer.py
+++ b/wpilib/wpilib/analogaccelerometer.py
@@ -39,6 +39,9 @@ class AnalogAccelerometer(LiveWindowSendable):
         LiveWindow.addSensorChannel("Accelerometer",
                                     self.analogChannel.getChannel(), self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+
     def getAcceleration(self):
         """Return the acceleration in Gs.
 

--- a/wpilib/wpilib/analoginput.py
+++ b/wpilib/wpilib/analoginput.py
@@ -56,6 +56,7 @@ class AnalogInput(SensorBase):
                       channel)
 
     def free(self):
+        LiveWindow.removeComponent(self)
         if self.channel is None:
             return
         AnalogInput.channels.free(self.channel)

--- a/wpilib/wpilib/analogoutput.py
+++ b/wpilib/wpilib/analogoutput.py
@@ -42,6 +42,7 @@ class AnalogOutput(SensorBase):
     def free(self):
         """Channel destructor.
         """
+        LiveWindow.removeComponent(self)
         if self.channel is None:
             return
         AnalogOutput.channels.free(self.channel)

--- a/wpilib/wpilib/builtinaccelerometer.py
+++ b/wpilib/wpilib/builtinaccelerometer.py
@@ -32,6 +32,9 @@ class BuiltInAccelerometer(LiveWindowSendable):
                       "Built-in accelerometer")
         LiveWindow.addSensor("BuiltInAccel", 0, self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+
     def setRange(self, range):
         """Set the measuring range of the accelerometer.
 

--- a/wpilib/wpilib/cantalon.py
+++ b/wpilib/wpilib/cantalon.py
@@ -168,6 +168,7 @@ class CANTalon(LiveWindowSendable, MotorSafety):
         return self._handle
 
     def free(self):
+        LiveWindow.removeComponent(self)
         self._handle_finalizer()
 
     def pidWrite(self, output):

--- a/wpilib/wpilib/digitalinput.py
+++ b/wpilib/wpilib/digitalinput.py
@@ -35,6 +35,10 @@ class DigitalInput(DigitalSource):
                       channel)
         LiveWindow.addSensorChannel("DigitalInput", channel, self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def get(self):
         """Get the value from a digital input channel. Retrieve the value of
         a single digital input channel from the FPGA.

--- a/wpilib/wpilib/doublesolenoid.py
+++ b/wpilib/wpilib/doublesolenoid.py
@@ -102,6 +102,7 @@ class DoubleSolenoid(SolenoidBase):
 
     def free(self):
         """Mark the solenoid as freed."""
+        LiveWindow.removeComponent(self)
         self.allocated.free(self.forwardChannel)
         self.allocated.free(self.reverseChannel)
 

--- a/wpilib/wpilib/encoder.py
+++ b/wpilib/wpilib/encoder.py
@@ -232,6 +232,7 @@ class Encoder(SensorBase):
         return self.encodingScale
 
     def free(self):
+        LiveWindow.removeComponent(self)
         if self.aSource is not None and self.allocatedA:
             self.aSource.free()
             self.allocatedA = False

--- a/wpilib/wpilib/geartooth.py
+++ b/wpilib/wpilib/geartooth.py
@@ -48,6 +48,10 @@ class GearTooth(Counter):
         LiveWindow.addSensorChannel("GearTooth", self.upSource.getChannel(),
                                     self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     # Live Window code, only does anything if live window is activated.
 
     def getSmartDashboardType(self):

--- a/wpilib/wpilib/gyro.py
+++ b/wpilib/wpilib/gyro.py
@@ -98,6 +98,7 @@ class Gyro(SensorBase):
         """Delete (free) the accumulator and the analog components used for the
         gyro.
         """
+        LiveWindow.removeComponent(self)
         if self.analog is not None:
             self.analog.free()
             self.analog = None

--- a/wpilib/wpilib/jaguar.py
+++ b/wpilib/wpilib/jaguar.py
@@ -45,6 +45,10 @@ class Jaguar(SafePWM):
                       self.getChannel())
         LiveWindow.addActuatorChannel("Jaguar", self.getChannel(), self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def set(self, speed, syncGroup=0):
         """Set the PWM value.
 

--- a/wpilib/wpilib/livewindow.py
+++ b/wpilib/wpilib/livewindow.py
@@ -82,8 +82,16 @@ class LiveWindow:
                     LiveWindow.firstTime = False
                 Scheduler.getInstance().disable()
                 Scheduler.getInstance().removeAll()
+                bad_components = []
                 for component in LiveWindow.components.keys():
-                    component.startLiveWindowMode()
+                    try:
+                        component.startLiveWindowMode()
+                    except Exception as e:
+                        logger.error("Exception running startLiveWindowMode() on {}, removing from component list.".format(component))
+                        logger.exception(e)
+                        bad_components.append(component)
+                for component in bad_components:
+                    del(LiveWindow.components[component])
             else:
                 logger.info("Stopping live window mode.")
                 for component in LiveWindow.components.keys():
@@ -181,3 +189,14 @@ class LiveWindow:
                 "Ungrouped",
                 "%s[%s,%s]" % (moduleType, moduleNumber, channel),
                 component)
+
+    @staticmethod
+    def removeComponent(component):
+        """Removes a component from LiveWindow.
+
+        :param component: The reference to the object being removed.
+        """
+        if component in LiveWindow.components:
+            if LiveWindow.components[component].isSensor:
+                LiveWindow.sensors.remove(component)
+            del(LiveWindow.components[component])

--- a/wpilib/wpilib/relay.py
+++ b/wpilib/wpilib/relay.py
@@ -117,6 +117,8 @@ class Relay(SensorBase):
             self.direction == self.Direction.kReverse):
             Relay.relayChannels.free(self.channel*2 + 1)
 
+        LiveWindow.removeComponent(self)
+
         self._port_finalizer()
 
     def set(self, value):

--- a/wpilib/wpilib/servo.py
+++ b/wpilib/wpilib/servo.py
@@ -45,6 +45,9 @@ class Servo(PWM):
         hal.HALReport(hal.HALUsageReporting.kResourceType_Servo,
                       self.getChannel())
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
 
     def set(self, value):
         """Set the servo position.

--- a/wpilib/wpilib/solenoid.py
+++ b/wpilib/wpilib/solenoid.py
@@ -81,6 +81,8 @@ class Solenoid(SolenoidBase):
     def free(self):
         """Mark the solenoid as freed."""
         self.allocated.free(self.channel)
+        LiveWindow.removeComponent(self)
+        super().free()
 
     def set(self, on):
         """Set the value of a solenoid.

--- a/wpilib/wpilib/talon.py
+++ b/wpilib/wpilib/talon.py
@@ -50,6 +50,10 @@ class Talon(SafePWM):
         hal.HALReport(hal.HALUsageReporting.kResourceType_Talon,
                       self.getChannel())
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def set(self, speed, syncGroup=0):
         """Set the PWM value.
 

--- a/wpilib/wpilib/talonsrx.py
+++ b/wpilib/wpilib/talonsrx.py
@@ -52,6 +52,10 @@ class TalonSRX(SafePWM):
         hal.HALReport(hal.HALUsageReporting.kResourceType_TalonSRX,
                       self.getChannel())
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def set(self, speed, syncGroup=0):
         """Set the PWM value.
 

--- a/wpilib/wpilib/ultrasonic.py
+++ b/wpilib/wpilib/ultrasonic.py
@@ -132,6 +132,10 @@ class Ultrasonic(SensorBase):
                       Ultrasonic.instances)
         LiveWindow.addSensor("Ultrasonic", self.echoChannel.getChannel(), self)
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def setAutomaticMode(self, enabling):
         """Turn Automatic mode on/off. When in Automatic mode, all sensors
         will fire in round robin, waiting a set time between each sensor.

--- a/wpilib/wpilib/victor.py
+++ b/wpilib/wpilib/victor.py
@@ -56,6 +56,10 @@ class Victor(SafePWM):
         hal.HALReport(hal.HALUsageReporting.kResourceType_Victor,
                       self.getChannel())
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def set(self, speed, syncGroup=0):
         """Set the PWM value.
 

--- a/wpilib/wpilib/victorsp.py
+++ b/wpilib/wpilib/victorsp.py
@@ -50,6 +50,10 @@ class VictorSP(SafePWM):
         hal.HALReport(hal.HALUsageReporting.kResourceType_VictorSP,
                       self.getChannel())
 
+    def free(self):
+        LiveWindow.removeComponent(self)
+        super().free()
+
     def set(self, speed, syncGroup=0):
         """Set the PWM value.
 


### PR DESCRIPTION
Added a try/except to catch any exceptions thrown by device's `.startLiveWindowMode()` hook.

Also added a `LiveView.removeComponent()` method, and now call it from the `free()` method of every device that has a `LiveWindow.addDevice()` in it's `__init__()`.

This fixes #148