### PR TITLE
Added warning to not use during official events in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 RobotPy WPILib
 ==============
 
+WARNING: This library is not officially supported by FIRST and therefore should be advised not to be used in competitions.
+Since python is not supported, Control System Advisors and Field Technical Adivsors are not trained and not required to assist
+if a non official language is used on a robot during an official FIRST event.
+The officially supported languages can be found here: [FRC Control Systems](https://wpilib.screenstepslive.com/s/4485)
+This project can be used in any manner outside of an official FIRST Robotics Event.
+
 [![Build Status](https://travis-ci.org/robotpy/robotpy-wpilib.svg)](https://travis-ci.org/robotpy/robotpy-wpilib)
 
-This repository contains the source code for a 100% python implementation of WPILib, 
-the library used to interface with hardware for the FIRST Robotics Competition. 
+This repository contains the source code for a 100% python implementation of WPILib,
+the library used to interface with hardware for the FIRST Robotics Competition.
 Teams can use this library to write their robot code in Python, a powerful dynamic
 programming language.
 
@@ -43,5 +49,3 @@ amount of work on the pure python port of WPILib, and various useful tooling.
 Other contributors include:
 
 * Sam Rosenblum (@sarosenb, FRC Team 2423)
-
-


### PR DESCRIPTION
tldr
Team used unofficial language at an event. Advise that this project should not be used at competitions.

So I was a CSA at an event and was not required to assist a team that was experiencing issued with their robot since they were using this library. I find this project to be awesome and a fun way to learn software outside of official FIRST events. But seeing as how python does not cooperate well with embedded systems, it may not be fully compatible running on a roborio. So I added a warning into the readme so this can be avoided in the future. If you wish to ignore my warning (as it is kind of a rant), please do so. This PR was issued right after a competition.

Thanks!