### PR TITLE
Fix internal "read" method name

### DIFF
--- a/wpilib/wpilib/preferences.py
+++ b/wpilib/wpilib/preferences.py
@@ -340,7 +340,7 @@ class Preferences:
             except ImportError:
                 pass
 
-    def read(self):
+    def _read(self):
         """The internal method to read from a file. This will be called in its
         own thread when the preferences singleton is first created.
         """


### PR DESCRIPTION
Based on line 85 and by comparison with the _write method, this appears to be a typo.