### PR TITLE
Update command classes for 2017

### DIFF
--- a/wpilib/wpilib/command/__init__.py
+++ b/wpilib/wpilib/command/__init__.py
@@ -17,12 +17,14 @@
 
 from .command import *
 from .commandgroup import *
+from .instantcommand import *
 from .pidcommand import *
 from .pidsubsystem import *
 from .printcommand import *
 from .scheduler import *
 from .startcommand import *
 from .subsystem import *
+from .timedcommand import *
 from .waitcommand import *
 from .waitforchildren import *
 from .waituntilcommand import *

--- a/wpilib/wpilib/command/command.py
+++ b/wpilib/wpilib/command/command.py
@@ -1,6 +1,6 @@
-# validated: 2016-01-09 AG 26d101c shared/java/edu/wpi/first/wpilibj/command/Command.java
+# validated: 2016-11-20 KC b25a7cb3704d shared/java/edu/wpi/first/wpilibj/command/Command.java
 #----------------------------------------------------------------------------
-# Copyright (c) FIRST 2008-2012. All Rights Reserved.
+# Copyright (c) FIRST 2008-2016. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code
 # must be accompanied by the FIRST BSD license file in the root directory of
 # the project.
@@ -172,7 +172,7 @@ class Command(Sendable):
         """The initialize method is called the first time this Command is run
         after being started.
         """
-        pass #raise NotImplementedError
+        pass
 
     def _initialize(self):
         """A shadow method called before initialize()."""
@@ -182,7 +182,7 @@ class Command(Sendable):
         """The execute method is called repeatedly until this Command either
         finishes or is canceled.
         """
-        pass #raise NotImplementedError
+        pass
 
     def _execute(self):
         """A shadow method called before execute()."""
@@ -193,19 +193,25 @@ class Command(Sendable):
         If it is, then the command will be removed and end() will be called.
 
         It may be useful for a team to reference the isTimedOut() method
-        for time-sensitive commands.
+        for time-sensitive commands, or override TimedCommand.
+
+        If you do not specify isFinished in your command, the command will only
+        end if interrupted or canceled. If you want a command that executes only
+        once and then ends, override InstantCommand.
 
         :returns: whether this command is finished.
         :see: :meth:`isTimedOut`
+        :see: :class: `.TimedCommand`
+        :see: :class: `.InstantCommand`
         """
-        raise NotImplementedError
+        return False
 
     def end(self):
         """Called when the command ended peacefully.  This is where you may
         want to wrap up loose ends, like shutting off a motor that was being
         used in the command.
         """
-        pass #raise NotImplementedError
+        pass
 
     def _end(self):
         """A shadow method called after end()."""
@@ -220,9 +226,9 @@ class Command(Sendable):
         motor that was being used in the command.
 
         Generally, it is useful to simply call the end() method within this
-        method.
+        method, as done here.
         """
-        pass #raise NotImplementedError
+        self.end()
 
     def _interrupted(self):
         """A shadow method called after interrupted()."""

--- a/wpilib/wpilib/command/instantcommand.py
+++ b/wpilib/wpilib/command/instantcommand.py
@@ -1,0 +1,24 @@
+# validated: 2016-11-20 KC b25a7cb3704d shared/java/edu/wpi/first/wpilibj/command/InstantCommand.java
+#----------------------------------------------------------------------------
+# Copyright (c) FIRST 2016. All Rights Reserved.
+# Open Source Software - may be modified and shared by FRC teams. The code
+# must be accompanied by the FIRST BSD license file in the root directory of
+# the project.
+#----------------------------------------------------------------------------
+from .command import Command
+
+__all__ = ["InstantCommand"]
+
+class InstantCommand(Command):
+    '''
+    A command that has no duration. Subclasses should implement the initialize()
+    method to carry out desired actions.
+    '''
+
+    def __init__(self, name):
+        super().__init__(name)
+
+
+    def isFinished(self):
+        return True
+

--- a/wpilib/wpilib/command/printcommand.py
+++ b/wpilib/wpilib/command/printcommand.py
@@ -1,16 +1,16 @@
-# validated: 2016-01-09 AG b62b606 shared/java/edu/wpi/first/wpilibj/command/PrintCommand.java
+# validated: 2016-11-20 KC b78f580d476f shared/java/edu/wpi/first/wpilibj/command/PrintCommand.java
 #----------------------------------------------------------------------------
-# Copyright (c) FIRST 2008-2012. All Rights Reserved.
+# Copyright (c) FIRST 2008-2016. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code
 # must be accompanied by the FIRST BSD license file in the root directory of
 # the project.
 #----------------------------------------------------------------------------
 
-from .command import Command
+from .instantcommand import InstantCommand
 
 __all__ = ["PrintCommand"]
 
-class PrintCommand(Command):
+class PrintCommand(InstantCommand):
     """A PrintCommand is a command which prints out a string when it is
     initialized, and then immediately finishes.
 
@@ -29,6 +29,3 @@ class PrintCommand(Command):
 
     def initialize(self):
         print(self.message)
-
-    def isFinished(self):
-        return True

--- a/wpilib/wpilib/command/startcommand.py
+++ b/wpilib/wpilib/command/startcommand.py
@@ -1,16 +1,16 @@
-# validated: 2016-01-09 AG b62b606 shared/java/edu/wpi/first/wpilibj/command/StartCommand.java
+# validated: 2016-11-20 KC b78f580d476f shared/java/edu/wpi/first/wpilibj/command/StartCommand.java
 #----------------------------------------------------------------------------
-# Copyright (c) FIRST 2008-2012. All Rights Reserved.
+# Copyright (c) FIRST 2008-2016. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code
 # must be accompanied by the FIRST BSD license file in the root directory of
 # the project.
 #----------------------------------------------------------------------------
 
-from .command import Command
+from .instantcommand import InstantCommand
 
 __all__ = ["StartCommand"]
 
-class StartCommand(Command):
+class StartCommand(InstantCommand):
     """A StartCommand will call the start() method of another command when it
     is initialized and will finish immediately.
     """
@@ -26,6 +26,3 @@ class StartCommand(Command):
 
     def initialize(self):
         self.commandToFork.start()
-
-    def isFinished(self):
-        return True

--- a/wpilib/wpilib/command/timedcommand.py
+++ b/wpilib/wpilib/command/timedcommand.py
@@ -1,0 +1,21 @@
+# validated: 2016-11-20 KC b25a7cb3704d shared/java/edu/wpi/first/wpilibj/command/TimedCommand.java
+#----------------------------------------------------------------------------
+# Copyright (c) FIRST 2016. All Rights Reserved.
+# Open Source Software - may be modified and shared by FRC teams. The code
+# must be accompanied by the FIRST BSD license file in the root directory of
+# the project.
+#----------------------------------------------------------------------------
+
+from .command import Command
+
+__all__ = ["TimedCommand"]
+
+class TimedCommand(Command):
+    '''A command that runs for a set period of time.'''
+
+    def __init__(self, name, timeoutInSeconds):
+        super().__init__(name, timeoutInSeconds)
+
+
+    def isFinished(self):
+        return self.isTimedOut()

--- a/wpilib/wpilib/command/waitcommand.py
+++ b/wpilib/wpilib/command/waitcommand.py
@@ -1,12 +1,12 @@
-# validated: 2016-01-09 AG b62b606 shared/java/edu/wpi/first/wpilibj/command/WaitCommand.java
+# validated: 2016-11-20 KC b78f580d476f shared/java/edu/wpi/first/wpilibj/command/WaitCommand.java
 #----------------------------------------------------------------------------
-# Copyright (c) FIRST 2008-2012. All Rights Reserved.
+# Copyright (c) FIRST 2008-2016. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code
 # must be accompanied by the FIRST BSD license file in the root directory of
 # the project.
 #----------------------------------------------------------------------------
 
-from .command import Command
+from .timedcommand import TimedCommand
 
 __all__ = ["WaitCommand"]
 
@@ -27,6 +27,3 @@ class WaitCommand(Command):
             super().__init__("Wait(%s)" % timeout, timeout)
         else:
             super().__init__(name, timeout)
-
-    def isFinished(self):
-        return self.isTimedOut()

--- a/wpilib/wpilib/command/waitforchildren.py
+++ b/wpilib/wpilib/command/waitforchildren.py
@@ -1,4 +1,4 @@
-# validated: 2016-01-09 AG b62b606 shared/java/edu/wpi/first/wpilibj/command/WaitForChildren.java
+# validated: 2016-11-20 KC b78f580d476f shared/java/edu/wpi/first/wpilibj/command/WaitForChildren.java
 #----------------------------------------------------------------------------
 # Copyright (c) FIRST 2008-2012. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code

--- a/wpilib/wpilib/command/waituntilcommand.py
+++ b/wpilib/wpilib/command/waituntilcommand.py
@@ -1,4 +1,4 @@
-# validated: 2016-01-09 AG 26d101c shared/java/edu/wpi/first/wpilibj/command/WaitUntilCommand.java
+# validated: 2016-11-20 KC b78f580d476f shared/java/edu/wpi/first/wpilibj/command/WaitUntilCommand.java
 #----------------------------------------------------------------------------
 # Copyright (c) FIRST 2008-2012. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code


### PR DESCRIPTION
Since we were the ones that got [these changes](https://github.com/wpilibsuite/allwpilib/pull/238) merged into WPILib, it seemed like our responsibility to handle the porting for Python. We are not a beta team, so we can't test with the new HAL, but the code works with last year's firmware and there are no low-level changes.