### PR TITLE
Add CANTalon and CANJaguar placeholders

### DIFF
--- a/wpilib/wpilib/__init__.py
+++ b/wpilib/wpilib/__init__.py
@@ -28,6 +28,8 @@ from .analogpotentiometer import *
 from .analogtrigger import *
 from .analogtriggeroutput import *
 from .builtinaccelerometer import *
+from .canjaguar import *
+from .cantalon import *
 from .compressor import *
 from .controllerpower import *
 from .counter import *

--- a/wpilib/wpilib/canjaguar.py
+++ b/wpilib/wpilib/canjaguar.py
@@ -1,0 +1,9 @@
+# Placeholder for the CANJaguar class, which has been removed
+
+__all__ = ["CANJaguar"]
+
+class CANJaguar:
+
+    def __init__(*args, **kwargs):
+        raise ValueError("CANJaguar has been removed from wpilib.")
+

--- a/wpilib/wpilib/cantalon.py
+++ b/wpilib/wpilib/cantalon.py
@@ -1,0 +1,9 @@
+# Placeholder for the CANTalon class, which has moved to its own package
+
+__all__ = ["CANTalon"]
+
+class CANTalon:
+
+    def __init__(*args, **kwargs):
+        raise ValueError("CANTalon has moved to ctre.CANTalon, you must install robotpy-ctre")
+


### PR DESCRIPTION
Placeholders for the CANTalon/CANJaguar classes that were removed. Both should throw an error when created. #212