### PR TITLE
Fixed the turning problem with mecanumDrive_Cartesian

### DIFF
--- a/wpilib/wpilib/robotdrive.py
+++ b/wpilib/wpilib/robotdrive.py
@@ -466,8 +466,8 @@ class RobotDrive(MotorSafety):
 
         wheelSpeeds = [0]*self.kMaxNumberOfMotors
         wheelSpeeds[self.MotorType.kFrontLeft] = xIn + yIn + rotation
-        wheelSpeeds[self.MotorType.kFrontRight] = -xIn + yIn - rotation
-        wheelSpeeds[self.MotorType.kRearLeft] = -xIn + yIn + rotation
+        wheelSpeeds[self.MotorType.kFrontRight] = -xIn + yIn + rotation
+        wheelSpeeds[self.MotorType.kRearLeft] = -xIn + yIn - rotation
         wheelSpeeds[self.MotorType.kRearRight] = xIn + yIn - rotation
 
         RobotDrive.normalize(wheelSpeeds)


### PR DESCRIPTION
Instead of turning, our robot spun wheels against itself and got nowhere. The front and rear wheels were spinning opposite each other in such a way that it didn't move sideways either. We determined that for our robot, the front right and rear left wheels were the ones spinning the wrong way. We also checked and made sure that our motors and motor controllers were all connected properly. So far unsure if others had this problem, but this was the case with our robot.