### PR TITLE
Fix Attribute Error

### DIFF
--- a/wpilib/wpilib/command/scheduler.py
+++ b/wpilib/wpilib/command/scheduler.py
@@ -235,7 +235,7 @@ class Scheduler(Sendable):
             for command in self.commandTable:
                 if id(command) in self.toCancel:
                     command.cancel()
-            self.toCancel.clear()
+            self.toCancel = []
             self.table.putNumberArray("Cancel", self.toCancel)
 
         if self.runningCommandsChanged:


### PR DESCRIPTION
When setting a Number array value, it is interpreted as a tuple, not a list. This line used a list method on the tuple, causing an attribute error when cancelling a command. This updated version will work whether the value is a tuple or a list.