### PR TITLE
getJoystickName shouldn't bomb out

### DIFF
--- a/hal-sim/hal_impl/data.py
+++ b/hal-sim/hal_impl/data.py
@@ -154,7 +154,8 @@ def _reset_hal_data(current_hooks):
             'has_source': IN(False),
             'buttons': IN([None] + [False]*12), # numbered 1-12 -- 0 is ignored
             'axes':    IN([0]*constants.kMaxJoystickAxes),  # x is 0, y is 1, .. 
-            'povs':    IN([-1]*constants.kMaxJoystickPOVs)  # integers
+            'povs':    IN([-1]*constants.kMaxJoystickPOVs), # integers
+            'name':    IN(''),
         
         } for _ in range(6)],
 

--- a/wpilib/wpilib/driverstation.py
+++ b/wpilib/wpilib/driverstation.py
@@ -345,7 +345,7 @@ class DriverStation:
 
         with self.joystickMutex:
             # TODO: Remove this when calling for descriptor on empty stick no longer crashes.
-            if 1 > self.joystickButtons[stick].count and 1 > len(self.joystickAxes[stick]):
+            if 1 > self.joystickButtons[stick].count and 1 > len(self.joystickAxes[stick].axes):
                 self._reportJoystickUnpluggedError("WARNING: Joystick on port {} not avaliable, check if controller is "
                                                    "plugged in.\n".format(stick))
                 return ""


### PR DESCRIPTION
also, add a slot for joystick name