### PR TITLE
docs: Skip undocumented classes

### DIFF
--- a/docs/regen.py
+++ b/docs/regen.py
@@ -80,6 +80,9 @@ def gen_package(mod):
     classes = []
     
     for clsname, cls in inspect.getmembers(mod, inspect.isclass):
+        # Skip undocumented classes - only stubs will be undocumented.
+        if not cls.__doc__:
+            continue
         
         fname = join(docdir, '%s.rst' % clsname)
         clsmodname = cls.__module__

--- a/wpilib/wpilib/buttons/joystickbutton.py
+++ b/wpilib/wpilib/buttons/joystickbutton.py
@@ -11,7 +11,7 @@ from .button import Button
 __all__ = ["JoystickButton"]
 
 class JoystickButton(Button):
-    """A :class:`.Button` that gets its state from a :class:`.GenericHID`."""
+    """A :class:`.Button` that gets its state from a :class:`GenericHID`."""
 
     def __init__(self, joystick, buttonNumber):
         """Create a joystick button for triggering commands.

--- a/wpilib/wpilib/buttons/networkbutton.py
+++ b/wpilib/wpilib/buttons/networkbutton.py
@@ -11,6 +11,8 @@ from .button import Button
 __all__ = ["NetworkButton"]
 
 class NetworkButton(Button):
+    """A :class:`.Button` that uses a :class:`NetworkTable` boolean field."""
+
     def __init__(self, table, field):
         from networktables import NetworkTables
         from networktables.networktable import NetworkTable

--- a/wpilib/wpilib/interfaces/potentiometer.py
+++ b/wpilib/wpilib/interfaces/potentiometer.py
@@ -11,5 +11,7 @@ from .pidsource import PIDSource
 __all__ = ["Potentiometer"]
 
 class Potentiometer(PIDSource):
+    """Interface for a Potentiometer."""
+
     def get(self):
         raise NotImplementedError


### PR DESCRIPTION
This causes the docs to skip generating documentation for classes that are not
documented.  This is intended to skip the CANTalon and CANJaguar stubs that were
added in 2017 to direct users to the relevant packages (or lack thereof).

This also documents a couple of classes in the buttons and interfaces packages
that were meant to be documented, but weren't.

I have verified that there are no other classes that are undocumented using the
following snippet:
```python
[x for package in [wpilib, wpilib.buttons, wpilib.command, wpilib.interfaces]
   for x in vars(package).values() if inspect.isclass(x) and not x.__doc__]
```

Fixes: #268