### PR TITLE
Validate LinearDigitalFilter

### DIFF
--- a/wpilib/wpilib/lineardigitalfilter.py
+++ b/wpilib/wpilib/lineardigitalfilter.py
@@ -1,4 +1,4 @@
-# validated: 2017-11-21 EN e1195e8b9dab edu/wpi/first/wpilibj/filters/LinearDigitalFilter.java
+# validated: 2017-12-08 DV 85157a56c3a7 edu/wpi/first/wpilibj/filters/LinearDigitalFilter.java
 #----------------------------------------------------------------------------
 # Copyright (c) FIRST 2016. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code


### PR DESCRIPTION
Upstream changed their CircularBuffer helper class to be more idiomatic, but we just use collections.deque.

(Maybe we want to reconsider this? Their CircularBuffer is array-backed and doesn't shuffle elements around, so it'd be more efficient than a doubly-linked list, right?)