### PR TITLE
Add missing call to super().__init__() in gyros

### DIFF
--- a/wpilib/wpilib/adxrs450_gyro.py
+++ b/wpilib/wpilib/adxrs450_gyro.py
@@ -50,6 +50,7 @@ class ADXRS450_Gyro(GyroBase):
             :param port: The SPI port that the gyro is connected to
             :type port: :class:`.SPI.Port`
         """
+        super().__init__()
         
         if port is None:
             port = SPI.Port.kOnboardCS0

--- a/wpilib/wpilib/analoggyro.py
+++ b/wpilib/wpilib/analoggyro.py
@@ -56,6 +56,7 @@ class AnalogGyro(GyroBase):
         :param offset: Preset uncalibrated value to use as the gyro offset
         :type offset: float
         """
+        super().__init__()
         
         if not hasattr(channel, "initAccumulator"):
             channel = AnalogInput(channel)


### PR DESCRIPTION
This ensures that these gyros work as a PIDSource as expected.

(Found this using lgtm.com. A fair few false positives there, but hey I found these.)