### PR TITLE
docs: Use sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
+    'sphinx_autodoc_typehints',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinx-rtd-theme
-mock
+sphinx-autodoc-typehints
 git+git://github.com/robotpy/pynetworktables.git


### PR DESCRIPTION
We're trying to move towards using type hints to aid tools like mypy.
This makes the type hints not look rubbish in the docs.