### PR TITLE
Add checks to ensure simulation HAL is not installed on RoboRIO

### DIFF
--- a/hal-roborio/setup.py
+++ b/hal-roborio/setup.py
@@ -7,6 +7,11 @@ import sys
 
 from setuptools import setup
 
+# Check to see if we're on a RoboRIO before potentially downloading anything
+if __name__ == '__main__' and len(sys.argv) > 1 and sys.argv[1] == 'install':
+    if not exists('/etc/natinst/share/scs_imagemetadata.ini'):
+        raise RuntimeError("This HAL should only be installed onto a RoboRIO. Perhaps try the `robotpy-hal-sim` package?")
+
 setup_dir = dirname(__file__)
 git_dir = join(setup_dir, '..', '.git')
 base_package = 'hal_impl'

--- a/hal-sim/setup.py
+++ b/hal-sim/setup.py
@@ -55,6 +55,8 @@ if __name__ == '__main__':
         if 'robotpy-hal-roborio' in installed_packages:
             raise RuntimeError("The simulation HAL cannot be installed alongside the RoboRIO HAL.")
 
+        # Another check to see if we're on a RoboRIO.
+        # NOTE: may have false positives, but it should work well enough
         if exists('/etc/natinst/share/scs_imagemetadata.ini'):
             raise RuntimeError("The simulation HAL should not be installed onto the RoboRIO. Perhaps try the `robotpy-hal-roborio` package?")
 

--- a/hal-sim/setup.py
+++ b/hal-sim/setup.py
@@ -3,6 +3,7 @@
 from os.path import dirname, exists, join
 import sys, subprocess
 from setuptools import setup
+import pip
 
 setup_dir = dirname(__file__)
 git_dir = join(setup_dir, '..', '.git')
@@ -46,10 +47,9 @@ if __name__ == '__main__':
 
         # Check to see if the RoboRIO HAL is installed before installing the
         # simulated HAL:
-        freeze_out = subprocess.check_output(['pip3', 'freeze'])
         installed_packages = [
-            line.decode().split('==')[0]
-            for line in freeze_out.splitlines()
+            dist.project_name
+            for dist in pip.utils.get_installed_distributions()
         ]
 
         if 'robotpy-hal-roborio' in installed_packages:

--- a/hal-sim/setup.py
+++ b/hal-sim/setup.py
@@ -39,26 +39,45 @@ else:
 with open(join(setup_dir, 'README.rst'), 'r') as readme_file:
     long_description = readme_file.read()
 
-setup(
-    name='robotpy-hal-sim',
-    version=__version__,
-    description='WPILib HAL layer for simulations',
-    long_description=long_description,
-    author='Peter Johnson, Dustin Spicuzza',
-    author_email='robotpy@googlegroups.com',
-    url='https://github.com/robotpy/robotpy-wpilib',
-    keywords='frc first robotics hal can',
-    packages=['hal_impl'],
-    install_requires='robotpy-hal-base==' + __version__, # is this a bad idea?
-    license="BSD License",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Topic :: Scientific/Engineering"
-    ]
-    )
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'install':
+        # setuptools doesn't seem to have a nice way of running checks before
+        # an install script runs, so I'm just going to do this and hope it works
+
+        # Check to see if the RoboRIO HAL is installed before installing the
+        # simulated HAL:
+        freeze_out = subprocess.check_output(['pip3', 'freeze'])
+        installed_packages = [
+            line.decode().split('==')[0]
+            for line in freeze_out.splitlines()
+        ]
+
+        if 'robotpy-hal-roborio' in installed_packages:
+            raise RuntimeError("The simulation HAL cannot be installed alongside the RoboRIO HAL.")
+
+        if exists('/etc/natinst/share/scs_imagemetadata.ini'):
+            raise RuntimeError("The simulation HAL should not be installed onto the RoboRIO. Perhaps try the `robotpy-hal-roborio` package?")
+
+    setup(
+        name='robotpy-hal-sim',
+        version=__version__,
+        description='WPILib HAL layer for simulations',
+        long_description=long_description,
+        author='Peter Johnson, Dustin Spicuzza',
+        author_email='robotpy@googlegroups.com',
+        url='https://github.com/robotpy/robotpy-wpilib',
+        keywords='frc first robotics hal can',
+        packages=['hal_impl'],
+        install_requires='robotpy-hal-base==' + __version__, # is this a bad idea?
+        license="BSD License",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers",
+            "Intended Audience :: Education",
+            "License :: OSI Approved :: BSD License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Topic :: Scientific/Engineering"
+        ]
+        )

--- a/hal-sim/setup.py
+++ b/hal-sim/setup.py
@@ -45,17 +45,6 @@ if __name__ == '__main__':
         # setuptools doesn't seem to have a nice way of running checks before
         # an install script runs, so I'm just going to do this and hope it works
 
-        # Check to see if the RoboRIO HAL is installed before installing the
-        # simulated HAL:
-        installed_packages = [
-            dist.project_name
-            for dist in pip.utils.get_installed_distributions()
-        ]
-
-        if 'robotpy-hal-roborio' in installed_packages:
-            raise RuntimeError("The simulation HAL cannot be installed alongside the RoboRIO HAL.")
-
-        # Another check to see if we're on a RoboRIO.
         # NOTE: may have false positives, but it should work well enough
         if exists('/etc/natinst/share/scs_imagemetadata.ini'):
             raise RuntimeError("The simulation HAL should not be installed onto the RoboRIO. Perhaps try the `robotpy-hal-roborio` package?")

--- a/hal-sim/setup.py
+++ b/hal-sim/setup.py
@@ -3,7 +3,6 @@
 from os.path import dirname, exists, join
 import sys, subprocess
 from setuptools import setup
-import pip
 
 setup_dir = dirname(__file__)
 git_dir = join(setup_dir, '..', '.git')

--- a/wpilib/wpilib/_impl/main.py
+++ b/wpilib/wpilib/_impl/main.py
@@ -42,6 +42,7 @@ def _log_versions():
         logger.info("Running with simulated HAL.")
 
         # check to see if we're on a RoboRIO
+        # NOTE: may have false positives, but it should work well enough
         if exists('/etc/natinst/share/scs_imagemetadata.ini'):
             logger.warning("Running simulation HAL on actual RoboRIO! This probably isn't what you want, and will probably cause difficult-to-debug issues!")
 

--- a/wpilib/wpilib/_impl/main.py
+++ b/wpilib/wpilib/_impl/main.py
@@ -4,6 +4,8 @@ import argparse
 import inspect
 import sys
 
+from os.path import exists
+
 from pkg_resources import iter_entry_points
 
 from .logconfig import configure_logging
@@ -19,10 +21,10 @@ def _log_versions():
     import wpilib
     import hal
     import hal_impl
-    
+
     import logging
     logger = logging.getLogger('wpilib')
-    
+
     logger.info("WPILib version %s", wpilib.__version__)
     logger.info("HAL base version %s; %s platform version %s",
                 hal.__version__,
@@ -30,12 +32,19 @@ def _log_versions():
                 hal_impl.__version__)
     if hasattr(hal_impl.version, "__hal_version__"):
         logger.info("HAL library version %s", hal_impl.version.__hal_version__)
-    
+
     # should we just die here?
     if hal.__version__ != wpilib.__version__ and \
        hal.__version__ != hal_impl.__version__:
         logger.warning("Core component versions are not identical! This is not a supported configuration, and you may run into errors!")
-        
+
+    if hal_impl.__hal_simulation__:
+        logger.info("Running with simulated HAL.")
+
+        # check to see if we're on a RoboRIO
+        if exists('/etc/natinst/share/scs_imagemetadata.ini'):
+            logger.warning("Running simulation HAL on actual RoboRIO! This probably isn't what you want, and will probably cause difficult-to-debug issues!")
+
     # Log third party versions
     # -> TODO: in the future, expand 3rd party HAL support here?
     for entry_point in iter_entry_points(group='robotpylib', name=None):
@@ -61,44 +70,44 @@ class _CustomHelpAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         parser.print_help()
         parser.exit(1)  # argparse uses an exit code of zero by default
-    
+
 argparse._HelpAction = _CustomHelpAction
-    
+
 def run(robot_class, **kwargs):
     '''
         This function gets called in robot.py like so::
-        
+
             if __name__ == '__main__':
                 wpilib.run(MyRobot)
-        
+
         This function loads available entry points, parses arguments, and
         sets things up specific to RobotPy so that the robot can run. This
         function is used whether the code is running on the roboRIO or
         a simulation.
-        
+
         :param robot_class: A class that inherits from :class:`.RobotBase`
         :param **kwargs: Keyword arguments that will be passed to the executed entry points
         :returns: This function should never return
     '''
-    
+
     sys.excepthook = ds_except_hook
     # sanity check
     if not hasattr(robot_class, 'main'):
         print("ERROR: run() must be passed a robot class that inherits from RobotBase (or IterativeBase/SampleBase)")
         exit(1)
-    
+
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers(dest='command', help="commands")
     subparser.required = True
-    
+
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help="Enable debug logging")
-    
+
     parser.add_argument('--ignore-plugin-errors', action='store_true', default=False,
                         help="Ignore errors caused by RobotPy plugins (probably should fix or replace instead!)")
-    
+
     has_cmd = False
-    
+
     for entry_point in iter_entry_points(group='robotpy', name=None):
         try:
             cmd_class = entry_point.load()
@@ -109,29 +118,28 @@ def run(robot_class, **kwargs):
             else:
                 print("Plugin error detected in '%s' (use --ignore-plugin-errors to ignore this)" % entry_point)
                 raise
-            
+
         cmdparser = subparser.add_parser(entry_point.name, help=inspect.getdoc(cmd_class))
         obj = cmd_class(cmdparser)
         cmdparser.set_defaults(cmdobj=obj)
         has_cmd = True
-        
+
     if not has_cmd:
         parser.error("No entry points defined -- robot code can't do anything. Install packages to add entry points (see README)")
         exit(1)
-    
+
     options = parser.parse_args()
-    
+
     configure_logging(options.verbose)
-    
+
     _log_versions()
     retval = options.cmdobj.run(options, robot_class, **kwargs)
-    
+
     if retval is None:
         retval = 0
     elif retval is True:
         retval = 0
     elif retval is False:
         retval = 1
-        
-    exit(retval)
 
+    exit(retval)

--- a/wpilib/wpilib/_impl/main.py
+++ b/wpilib/wpilib/_impl/main.py
@@ -44,7 +44,7 @@ def _log_versions():
         # check to see if we're on a RoboRIO
         # NOTE: may have false positives, but it should work well enough
         if exists('/etc/natinst/share/scs_imagemetadata.ini'):
-            logger.warning("Running simulation HAL on actual RoboRIO! This probably isn't what you want, and will probably cause difficult-to-debug issues!")
+            logger.warning("Running simulation HAL on actual roboRIO! This probably isn't what you want, and will probably cause difficult-to-debug issues!")
 
     # Log third party versions
     # -> TODO: in the future, expand 3rd party HAL support here?

--- a/wpilib/wpilib/_impl/main.py
+++ b/wpilib/wpilib/_impl/main.py
@@ -38,7 +38,7 @@ def _log_versions():
        hal.__version__ != hal_impl.__version__:
         logger.warning("Core component versions are not identical! This is not a supported configuration, and you may run into errors!")
 
-    if hal_impl.__hal_simulation__:
+    if hal.isSimulation():
         logger.info("Running with simulated HAL.")
 
         # check to see if we're on a RoboRIO


### PR DESCRIPTION
This should fix #303.

This adds some fairly simple checks to make sure that the `robotpy-hal-sim` package isn't accidentally installed onto an actual RoboRIO. This also adds logging to `wpilib.run` that indicates when a simulated HAL is in use, and warns whenever a simulated HAL is being used on a RoboRIO.