### PR TITLE
Fix version display on Read the Docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 git+git://github.com/robotpy/pynetworktables.git
+-e ../wpilib


### PR DESCRIPTION
We weren't installing the wpilib package on RTD.  This prevented the
generation of the version file, which in turn led to the docs not
showing the version as 'master' instead of the actual version.