### PR TITLE
Remove SensorBase.free() method

### DIFF
--- a/wpilib/wpilib/sensorbase.py
+++ b/wpilib/wpilib/sensorbase.py
@@ -162,8 +162,3 @@ class SensorBase(SendableBase):
         :returns: The number of the default solenoid module.
         """
         return SensorBase.defaultSolenoidModule
-
-    def free(self):
-        """Free the resources used by this object"""
-        # TODO: delete?
-        pass


### PR DESCRIPTION
Let these calls go up to SendableBase.free().

Upstream doesn't have a free method here anyway.