### PR TITLE
docs: Delete LiveWindowSendable exclude-members

### DIFF
--- a/docs/regen.py
+++ b/docs/regen.py
@@ -11,11 +11,8 @@
 import os
 import sys
 import inspect
-import shutil
 
 from os.path import abspath, join, dirname, exists
-
-import sphinx.apidoc
 
 mod_doc = '''
 %(header)s
@@ -40,7 +37,6 @@ cls_doc = '''
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: initTable, getTable, getSmartDashboardType, updateTable, startLiveWindowMode, stopLiveWindowMode, valueChanged
 '''
 
 def heading(name, c):


### PR DESCRIPTION
Now that we have all the LiveWindow/Sendable changes for this year,
these boilerplate methods no longer exist.  Stop excluding them so they
show up in the docs for the deprecated LiveWindowSendable and
NamedSendable stubs.