### PR TITLE
Bump pynetworktables dependency

### DIFF
--- a/wpilib/setup.py
+++ b/wpilib/setup.py
@@ -50,7 +50,7 @@ setup(
     url='https://github.com/robotpy/robotpy-wpilib',
     keywords='frc first robotics wpilib',
     packages=find_packages(),
-    install_requires=['pynetworktables>=2017.0.8'] if not os.environ.get('ROBOTPY_NO_DEPS') else None,
+    install_requires=['pynetworktables>=2018.0.0'],
     license="BSD License",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/wpilib/travis-requirements.txt
+++ b/wpilib/travis-requirements.txt
@@ -1,8 +1,9 @@
+git+git://github.com/robotpy/pynetworktables.git
+
 -e .
 -e ../hal-base
 -e ../hal-sim
 
-git+git://github.com/robotpy/pynetworktables.git
 git+git://github.com/robotpy/pyfrc.git
 
 pytest>=2.8


### PR DESCRIPTION
Also reorder the requirements.txt so that pynetworktables is actually
installed first.  This eliminates the need for the ROBOTPY_NO_DEPS
environment variable for wpilib's setup.py.