### PR TITLE
Provide printTrace parameter in calls to DriverStation.reportWarning/Error

### DIFF
--- a/wpilib/wpilib/robotbase.py
+++ b/wpilib/wpilib/robotbase.py
@@ -16,14 +16,14 @@ __all__ = ["RobotBase"]
 
 class RobotBase:
     """Implement a Robot Program framework.
-    
+
     The RobotBase class is intended to be subclassed by a user creating a
     robot program.  Overridden ``autonomous()`` and ``operatorControl()`` methods
     are called at the appropriate time as the match proceeds. In the current
     implementation, the Autonomous code will run to completion before the
     OperatorControl code could start. In the future the Autonomous code might
     be spawned as a task, then killed at the end of the Autonomous period.
-    
+
     User code should be placed in the constructor that runs before the
     Autonomous or Operator Control period starts. The constructor will
     run to completion before Autonomous is entered.
@@ -31,18 +31,18 @@ class RobotBase:
     .. warning:: If you override ``__init__`` in your robot class, you must call
                  the base class constructor. This must be used to ensure that
                  the communications code starts.
-                 
+
     .. not_implemented: getBooleanProperty
     """
 
     def __init__(self):
         NetworkTables.setNetworkIdentity("Robot")
-        
+
         if self.isReal():
             NetworkTables.startServer("/home/lvuser/networktables.ini")
         else:
             NetworkTables.startServer()
-        
+
         from .driverstation import DriverStation
         self.ds = DriverStation.getInstance()
 
@@ -125,7 +125,7 @@ class RobotBase:
     @staticmethod
     def initializeHardwareConfiguration():
         """Common initialization for all robot programs."""
-        
+
         # Python specific: do not call this, initialize() is already called when
         # hal is imported
         #hal.initialize()
@@ -147,15 +147,15 @@ class RobotBase:
         except:
             from .driverstation import DriverStation
             DriverStation.reportError("Unhandled exception instantiating robot " + robot_cls.__name__, True)
-            DriverStation.reportWarning("Robots should not quit, but yours did!")
+            DriverStation.reportWarning("Robots should not quit, but yours did!", False)
             DriverStation.reportError("Could not instantiate robot "+robot_cls.__name__+"!")
             return False
-        
+
         # Add a check to see if the user forgot to call super().__init__()
         if not hasattr(robot, '_RobotBase__initialized'):
             logger.error("If your robot class has an __init__ function, it must call super().__init__()!")
             return False
-        
+
         if not hal.isSimulation():
             try:
                 import wpilib
@@ -173,12 +173,12 @@ class RobotBase:
         except:
             from .driverstation import DriverStation
             DriverStation.reportError("Unhandled exception", True)
-            DriverStation.reportWarning("Robots should not quit, but yours did!")
+            DriverStation.reportWarning("Robots should not quit, but yours did!", False)
             DriverStation.reportError("The startCompetition() method (or methods called by it) should have handled the exception above.")
             return False
         else:
             # startCompetition never returns unless exception occurs....
             from .driverstation import DriverStation
-            DriverStation.reportWarning("Robots should not quit, but yours did!")
+            DriverStation.reportWarning("Robots should not quit, but yours did!", False)
             DriverStation.reportError("Unexpected return from startCompetition() method.")
             return False

--- a/wpilib/wpilib/robotbase.py
+++ b/wpilib/wpilib/robotbase.py
@@ -148,7 +148,7 @@ class RobotBase:
             from .driverstation import DriverStation
             DriverStation.reportError("Unhandled exception instantiating robot " + robot_cls.__name__, True)
             DriverStation.reportWarning("Robots should not quit, but yours did!", False)
-            DriverStation.reportError("Could not instantiate robot "+robot_cls.__name__+"!")
+            DriverStation.reportError("Could not instantiate robot "+robot_cls.__name__+"!", False)
             return False
 
         # Add a check to see if the user forgot to call super().__init__()
@@ -174,11 +174,11 @@ class RobotBase:
             from .driverstation import DriverStation
             DriverStation.reportError("Unhandled exception", True)
             DriverStation.reportWarning("Robots should not quit, but yours did!", False)
-            DriverStation.reportError("The startCompetition() method (or methods called by it) should have handled the exception above.")
+            DriverStation.reportError("The startCompetition() method (or methods called by it) should have handled the exception above.", False)
             return False
         else:
             # startCompetition never returns unless exception occurs....
             from .driverstation import DriverStation
             DriverStation.reportWarning("Robots should not quit, but yours did!", False)
-            DriverStation.reportError("Unexpected return from startCompetition() method.")
+            DriverStation.reportError("Unexpected return from startCompetition() method.", False)
             return False


### PR DESCRIPTION
Currently a new warning is caused whenever the `Robots shouldn't quit...` error is reported. In wpilibj the `printTrace` argument is `false` in all calls, so I've updated it to be that way here as well.