### PR TITLE
Don't decode string gameSpecificMessage

### DIFF
--- a/hal-sim/hal_impl/functions.py
+++ b/hal-sim/hal_impl/functions.py
@@ -1067,7 +1067,7 @@ def getMatchInfo():
     info.matchType = evt['match_type']
     info.matchNumber = evt['match_number']
     info.replayNumber = evt['replay_number']
-    info.gameSpecificMessage = bytes(evt['game_specific_message'], 'utf-8')
+    info.gameSpecificMessage = evt['game_specific_message']
     return 0, info
 
 def freeMatchInfo(info):

--- a/wpilib/wpilib/driverstation.py
+++ b/wpilib/wpilib/driverstation.py
@@ -499,7 +499,7 @@ class DriverStation:
         :returns: The game specific message
         """
         with self.cacheDataMutex:
-            return self.matchInfo.gameSpecificMessage.decode('utf-8')
+            return self.matchInfo.gameSpecificMessage
 
     def getEventName(self) -> str:
         """Get the event name


### PR DESCRIPTION
This was causing some issues for me, see screenshot. From my reading of the [Control System docs](http://wpilib.screenstepslive.com/s/currentCS/m/getting_started/l/826278-2018-game-data-details), the `gameSpecificMessage` is returned as a string.
![gsm](https://user-images.githubusercontent.com/5923662/34855964-ab287d2c-f710-11e7-9e94-281a8667668c.png)
