### PR TITLE
Add _reset() method for Preferences

### DIFF
--- a/wpilib/wpilib/preferences.py
+++ b/wpilib/wpilib/preferences.py
@@ -50,6 +50,10 @@ class Preferences:
             Preferences.instance = Preferences()
         return Preferences.instance
 
+    @classmethod
+    def _reset(cls):
+        del cls.instance
+
     def __init__(self):
         """Creates a preference class that will automatically read the file in
         a different thread. Any call to its methods will be blocked until the
@@ -138,7 +142,7 @@ class Preferences:
     def __setitem__(self, key, value):
         """Python style setting of key/value."""
         self.table.putString(key, str(value))
-  
+
     def containsKey(self, key):
         """Returns whether or not there is a key with the given name.
 


### PR DESCRIPTION
This gives `wpilib.Preferences` a `_reset()` method to keep it from holding on to `NetworkTable` instances between tests and NetworkTables resets. This fixes #427.

More generally, this issue happens with code similar to the following:
```
if table is None:
    table = NetworkTables.getTable(<whatever>)
```
where `table` has lifetime extending past the Robot class instance. When this happens, all tests past the second will use the `table` instance from the first test, which will cause errors when keys in `table` are accessed.