### PR TITLE
Return self in isInverted

### DIFF
--- a/wpilib/wpilib/pwmspeedcontroller.py
+++ b/wpilib/wpilib/pwmspeedcontroller.py
@@ -39,6 +39,7 @@ class PWMSpeedController(SafePWM):
         :param isInverted: The state of inversion (True is inverted).
         """
         self.isInverted = isInverted
+        return self
 
     def getInverted(self):
         """


### PR DESCRIPTION
this lets you invert in constructor of speedcontrollergroup (or other things) without having to create a local variable

I made a PR to wpilib. I doubt they'll merge. This...shouldn't be breaking though. 