### PR TITLE
DriverStation: Send actual control word over NT

### DIFF
--- a/hal-roborio/hal_impl/types.py
+++ b/hal-roborio/hal_impl/types.py
@@ -39,6 +39,12 @@ class ControlWord(C.Structure):
                 ("fmsAttached", C.c_uint32, 1),
                 ("dsAttached", C.c_uint32, 1),
                 ("control_reserved", C.c_uint32, 26)]
+
+    _c_int32_p = C.POINTER(C.c_int32)
+
+    def to_bits(self) -> int:
+        return C.cast(C.pointer(self), self._c_int32_p).contents.value
+
 ControlWord_ptr = C.POINTER(ControlWord)
 
 class JoystickAxes(C.Structure):

--- a/hal-sim/hal_impl/types.py
+++ b/hal-sim/hal_impl/types.py
@@ -51,7 +51,13 @@ def fake_pointer(orig_obj, name=None):
 #############################################################################
 
 class ControlWord:
-    
+    ENABLED_FIELD = 0
+    AUTO_FIELD = 1
+    TEST_FIELD = 2
+    EMERGENCY_STOP_FIELD = 3
+    FMS_ATTACHED_FIELD = 4
+    DS_ATTACHED_FIELD = 5
+
     def __init__(self):
         self.enabled = 0
         self.autonomous = 0
@@ -59,7 +65,15 @@ class ControlWord:
         self.eStop = 0
         self.fmsAttached = 0
         self.dsAttached = 0
-    
+
+    def to_bits(self) -> int:
+        return (self.enabled << self.ENABLED_FIELD
+                | self.autonomous << self.AUTO_FIELD
+                | self.test << self.TEST_FIELD
+                | self.eStop << self.EMERGENCY_STOP_FIELD
+                | self.fmsAttached << self.FMS_ATTACHED_FIELD
+                | self.dsAttached << self.DS_ATTACHED_FIELD)
+
 ControlWord_ptr = fake_pointer(ControlWord)
 
 class JoystickAxes:

--- a/wpilib/wpilib/driverstation.py
+++ b/wpilib/wpilib/driverstation.py
@@ -707,7 +707,9 @@ class DriverStation:
         self.matchDataSender.matchNumber.setDouble(matchNumber)
         self.matchDataSender.replayNumber.setDouble(replayNumber)
         self.matchDataSender.matchType.setDouble(matchType)
-        #self.matchDataSender.controlWord.setDouble(...)
+
+        with self.controlWordMutex:
+            self.matchDataSender.controlWord.setDouble(self.controlWordCache.to_bits())
 
     def _getData(self):
         """Copy data from the DS task for the user.


### PR DESCRIPTION
This allows Shuffleboard's basic FMS info widget to correctly report the robot status.

Whilst I haven't had a chance to test this on a roboRIO, the ctypes magic works correctly in simulation as well (it was actually the original simulation implementation too, but I decided against using in simulation).

I'm still unsure whether this is actually the approach we should take in simulation, or whether we should actually use the ctypes hackery in simulation too. (I think we do want to use the ctypes magic on the roboRIO though, as I believe it will be faster, but again I haven't checked that.)