### PR TITLE
Move decoding strings in match info to HAL

### DIFF
--- a/hal-base/hal/functions.py
+++ b/hal-base/hal/functions.py
@@ -356,11 +356,11 @@ _freeMatchInfo = _RETFUNC("freeMatchInfo", None, ("info", MatchInfo_ptr))
 def getMatchInfo(cachedInfo):
     ret, info = _getMatchInfo()
     if ret == 0:
-        cachedInfo.eventName = info.eventName
+        cachedInfo.eventName = info.eventName.decode('utf-8')
         cachedInfo.matchType = info.matchType
         cachedInfo.matchNumber = info.matchNumber
         cachedInfo.replayNumber = info.replayNumber
-        cachedInfo.gameSpecificMessage = info.gameSpecificMessage
+        cachedInfo.gameSpecificMessage = info.gameSpecificMessage.decode('utf-8')
         _freeMatchInfo(info)
     return ret
     

--- a/hal-sim/hal_impl/data.py
+++ b/hal-sim/hal_impl/data.py
@@ -129,11 +129,11 @@ def _reset_hal_data(current_hooks):
 
         # HAL MatchInfo data
         'event': {
-            'name': OUT('sim-event'),
-            'match_type': OUT(0),
-            'match_number': OUT(0),
-            'replay_number': OUT(0),
-            'game_specific_message': OUT('')
+            'name': IN('sim-event'),
+            'match_type': IN(0),
+            'match_number': IN(0),
+            'replay_number': IN(0),
+            'game_specific_message': IN('')
         },
 
         # You should not modify these directly, instead use the mode_helpers!

--- a/wpilib/tests/test_driverstation.py
+++ b/wpilib/tests/test_driverstation.py
@@ -259,15 +259,17 @@ def test_InTest(dsmock):
     dsmock.InTest(False)
     assert not dsmock.userInTest
 
+def test_event_data(ds, hal_data):
+    hal_data['event']['name'] = 'my-event'
+    ds._getData()
+    assert ds.getEventName() == 'my-event'
+
+def test_game_data(ds, hal_data):
+    hal_data['event']['game_specific_message'] = 'LRL'
+    ds._getData()
+    assert ds.getGameSpecificMessage() == 'LRL'
 
 # HAL-only tests
-
-def test_event_data(hal, hal_data):
-    hal_data['event']['name'] = 'my-event'
-    info = hal.MatchInfo()
-    ret = hal.getMatchInfo(info)
-    assert ret == 0
-    assert info.eventName == b'my-event'
 
 def test_joystick_name(hal, hal_data):
     hal_data['joysticks'][0]['name'] = 'joy0'

--- a/wpilib/wpilib/driverstation.py
+++ b/wpilib/wpilib/driverstation.py
@@ -24,6 +24,18 @@ logger = logging.getLogger('wpilib.ds')
 JOYSTICK_UNPLUGGED_MESSAGE_INTERVAL = 1.0
 
 
+# NOTE: Not using hal.MatchInfo to avoid having to constantly decode the bytestrings.
+class MatchInfoData:
+    __slots__ = ('eventName', 'matchType', 'matchNumber', 'replayNumber', 'gameSpecificMessage')
+
+    def __init__(self):
+        self.eventName = ''
+        self.matchType = 0
+        self.matchNumber = 0
+        self.replayNumber = 0
+        self.gameSpecificMessage = ''
+
+
 class MatchDataSender:
     def __init__(self):
         self.table = NetworkTables.getTable('FMSInfo')
@@ -114,7 +126,7 @@ class DriverStation:
         self.joystickAxes = [hal.JoystickAxes() for _ in range(self.kJoystickPorts)]
         self.joystickPOVs = [hal.JoystickPOVs() for _ in range(self.kJoystickPorts)]
         self.joystickButtons = [hal.JoystickButtons() for _ in range(self.kJoystickPorts)]
-        self.matchInfo = hal.MatchInfo(eventName=b'', gameSpecificMessage=b'')
+        self.matchInfo = MatchInfoData()
 
         self.joystickButtonsPressed = [hal.JoystickButtons() for _ in range(self.kJoystickPorts)]
         self.joystickButtonsReleased = [hal.JoystickButtons() for _ in range(self.kJoystickPorts)]
@@ -122,7 +134,7 @@ class DriverStation:
         self.joystickAxesCache = [hal.JoystickAxes() for _ in range(self.kJoystickPorts)]
         self.joystickPOVsCache = [hal.JoystickPOVs() for _ in range(self.kJoystickPorts)]
         self.joystickButtonsCache = [hal.JoystickButtons() for _ in range(self.kJoystickPorts)]
-        self.matchInfoCache = hal.MatchInfo(eventName=b'', gameSpecificMessage=b'')
+        self.matchInfoCache = MatchInfoData()
 
         self.controlWordMutex = threading.RLock()
         self.controlWordCache = hal.ControlWord()
@@ -546,15 +558,15 @@ class DriverStation:
         :returns: The game specific message
         """
         with self.cacheDataMutex:
-            return self.matchInfo.gameSpecificMessage.decode('utf-8')
+            return self.matchInfo.gameSpecificMessage
 
     def getEventName(self) -> str:
-        """Get the event name
+        """Get the event name.
 
         :returns: The event name
         """
         with self.cacheDataMutex:
-            return self.matchInfo.eventName.decode('utf-8')
+            return self.matchInfo.eventName
 
     def getMatchType(self) -> MatchType:
         """Get the match type.
@@ -694,8 +706,8 @@ class DriverStation:
         stationNumber = self._station_numbers.get(alliance, 0)
 
         with self.cacheDataMutex:
-            eventName = self.matchInfo.eventName.decode('utf-8')
-            gameSpecificMessage = self.matchInfo.gameSpecificMessage.decode('utf-8')
+            eventName = self.matchInfo.eventName
+            gameSpecificMessage = self.matchInfo.gameSpecificMessage
             matchNumber = self.matchInfo.matchNumber
             replayNumber = self.matchInfo.replayNumber
             matchType = self.matchInfo.matchType


### PR DESCRIPTION
Since DriverStation now constantly sends match info to the dashboard
over NetworkTables, having to decode multiple times is wasteful.

This is the same approach WPILibJ uses anyhow.