### PR TITLE
Avoid adding to LiveWindow where WPILibJ doesn't

### DIFF
--- a/wpilib/wpilib/adxrs450_gyro.py
+++ b/wpilib/wpilib/adxrs450_gyro.py
@@ -49,7 +49,7 @@ class ADXRS450_Gyro(GyroBase):
             :param port: The SPI port that the gyro is connected to
             :type port: :class:`.SPI.Port`
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
 
         if port is None:
             port = SPI.Port.kOnboardCS0

--- a/wpilib/wpilib/analogaccelerometer.py
+++ b/wpilib/wpilib/analogaccelerometer.py
@@ -33,7 +33,7 @@ class AnalogAccelerometer(SensorBase):
         :param channel: port index or an already initialized AnalogInput
         :type channel: int or :class:`.AnalogInput`
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         if not hasattr(channel, "getAverageVoltage"): # If 'channel' is an integer
             self.analogChannel = AnalogInput(channel)
             self.allocatedChannel = True

--- a/wpilib/wpilib/analoggyro.py
+++ b/wpilib/wpilib/analoggyro.py
@@ -54,7 +54,7 @@ class AnalogGyro(GyroBase):
         :param offset: Preset uncalibrated value to use as the gyro offset
         :type offset: float
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         
         if not hasattr(channel, "initAccumulator"):
             channel = AnalogInput(channel)

--- a/wpilib/wpilib/analoginput.py
+++ b/wpilib/wpilib/analoginput.py
@@ -48,8 +48,7 @@ class AnalogInput(SensorBase):
 
         :param channel: The channel number to represent. 0-3 are on-board 4-7 are on the MXP port.
         """
-        
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         SensorBase.checkAnalogInputChannel(channel)
         
         self.channel = channel

--- a/wpilib/wpilib/analogoutput.py
+++ b/wpilib/wpilib/analogoutput.py
@@ -27,7 +27,7 @@ class AnalogOutput(SensorBase):
 
         :param channel: The channel number to represent.
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         SensorBase.checkAnalogOutputChannel(channel)
         
         self.channel = channel

--- a/wpilib/wpilib/analogpotentiometer.py
+++ b/wpilib/wpilib/analogpotentiometer.py
@@ -45,8 +45,7 @@ class AnalogPotentiometer(SensorBase):
             the zero value.  Defaults to 0.0 if unspecified.
         :type  offset: float
         """
-
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         if not hasattr(channel, "getVoltage"):
             channel = AnalogInput(channel)
             self.addChild(channel)

--- a/wpilib/wpilib/analogtrigger.py
+++ b/wpilib/wpilib/analogtrigger.py
@@ -46,7 +46,7 @@ class AnalogTrigger(SensorBase):
             trigger.  Treated as an AnalogInput if the provided object has a
             getChannel function.
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         if not hasattr(channel, "getChannel"):
             self.analogInput = AnalogInput(channel)
             self.ownsAnalog = True

--- a/wpilib/wpilib/builtinaccelerometer.py
+++ b/wpilib/wpilib/builtinaccelerometer.py
@@ -27,7 +27,7 @@ class BuiltInAccelerometer(SensorBase):
             +/-8g if unspecified.
         :type  range: :class:`.Accelerometer.Range`
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.setRange(range)
         self.xEntry = None
         self.yEntry = None

--- a/wpilib/wpilib/buttons/joystickbutton.py
+++ b/wpilib/wpilib/buttons/joystickbutton.py
@@ -21,7 +21,7 @@ class JoystickButton(Button):
         :param buttonNumber: The button number
                              (see :meth:`.GenericHID.getRawButton`)
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.joystick = joystick
         self.buttonNumber = buttonNumber
 

--- a/wpilib/wpilib/command/scheduler.py
+++ b/wpilib/wpilib/command/scheduler.py
@@ -48,7 +48,7 @@ class Scheduler(SendableBase):
     def __init__(self):
         """Instantiates a Scheduler.
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         hal.report(hal.UsageReporting.kResourceType_Command,
                    hal.UsageReporting.kCommand_Scheduler)
         self.setName("Scheduler")

--- a/wpilib/wpilib/command/subsystem.py
+++ b/wpilib/wpilib/command/subsystem.py
@@ -37,7 +37,7 @@ class Subsystem(SendableBase):
         :param name: the name of the subsystem; if None, it will be set to the
                      name to the name of the class.
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         # The name
         if name is None:
             name = self.__class__.__name__

--- a/wpilib/wpilib/compressor.py
+++ b/wpilib/wpilib/compressor.py
@@ -26,7 +26,7 @@ class Compressor(SendableBase):
         
         :param module: The PCM CAN device ID. (0 - 62 inclusive)
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.table = None
         if module is None:
             module = SensorBase.getDefaultSolenoidModule()

--- a/wpilib/wpilib/counter.py
+++ b/wpilib/wpilib/counter.py
@@ -105,8 +105,7 @@ class Counter(SensorBase):
             to k1X if unspecified.  Only used when two sources are specified.
         :type encodingType: :class:`.Counter.EncodingType`
         """
-
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         source_identifier = [int, HasAttribute("getPortHandleForRouting"), HasAttribute("createOutput")]
 
         argument_templates = [[],

--- a/wpilib/wpilib/digitalglitchfilter.py
+++ b/wpilib/wpilib/digitalglitchfilter.py
@@ -27,7 +27,7 @@ class DigitalGlitchFilter(SensorBase):
     filterAllocated = [False]*3
 
     def __init__(self):
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.channelIndex = -1
         with self.mutex:
             for i, v in enumerate(self.filterAllocated):

--- a/wpilib/wpilib/digitaloutput.py
+++ b/wpilib/wpilib/digitaloutput.py
@@ -6,7 +6,6 @@
 # the project.
 # ----------------------------------------------------------------------------
 
-import warnings
 import weakref
 
 import hal
@@ -36,8 +35,7 @@ class DigitalOutput(SendableBase):
 
         :param channel: the DIO channel for the digital output. 0-9 are on-board, 10-25 are on the MXP
         """
-
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self._pwmGenerator = None
         self._pwmGenerator_finalizer = None
 

--- a/wpilib/wpilib/drive/robotdrivebase.py
+++ b/wpilib/wpilib/drive/robotdrivebase.py
@@ -43,7 +43,7 @@ class RobotDriveBase(SendableBase, MotorSafety):
     kDefaultMaxOutput = 1.0
 
     def __init__(self):
-        SendableBase.__init__(self)
+        SendableBase.__init__(self, addLiveWindow=False)
         MotorSafety.__init__(self)
 
         self.deadband = self.kDefaultDeadband

--- a/wpilib/wpilib/encoder.py
+++ b/wpilib/wpilib/encoder.py
@@ -121,7 +121,7 @@ class Encoder(SensorBase):
             spec'd count.  Defaults to k4X if unspecified.
         :type encodingType: :class:`Encoder.EncodingType`
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         a_source_arg = ("aSource", HasAttribute("getPortHandleForRouting"))
         b_source_arg = ("bSource", HasAttribute("getPortHandleForRouting"))
         index_source_arg = ("indexSource", HasAttribute("getPortHandleForRouting"))

--- a/wpilib/wpilib/gyrobase.py
+++ b/wpilib/wpilib/gyrobase.py
@@ -20,8 +20,8 @@ class GyroBase(SensorBase):
     
     PIDSourceType = PIDSource.PIDSourceType
     
-    def __init__(self):
-        super().__init__()
+    def __init__(self, addLiveWindow=True):
+        super().__init__(addLiveWindow=addLiveWindow)
         self.pidSource = self.PIDSourceType.kDisplacement
         self.valueEntry = None
     

--- a/wpilib/wpilib/interruptablesensorbase.py
+++ b/wpilib/wpilib/interruptablesensorbase.py
@@ -26,7 +26,7 @@ class InterruptableSensorBase(SensorBase):
 
     def __init__(self):
         """Create a new InterrupatableSensorBase"""
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         # The interrupt resource
         self._interrupt = None
         self._interrupt_finalizer = None

--- a/wpilib/wpilib/nidecbrushless.py
+++ b/wpilib/wpilib/nidecbrushless.py
@@ -26,7 +26,7 @@ class NidecBrushless(SendableBase, MotorSafety, SpeedController):
         :param dioChannel: The DIO channel that the Nidec Brushless controller is attached to.
                 0-9 are on-board, 10-25 are on the MXP port
         """
-        super().__init__()
+        SendableBase.__init__(self, addLiveWindow=False)
         self.dio = DigitalOutput(dioChannel)
         self.addChild(self.dio)
         self.dio.setPWMRate(15625)

--- a/wpilib/wpilib/powerdistributionpanel.py
+++ b/wpilib/wpilib/powerdistributionpanel.py
@@ -24,7 +24,7 @@ class PowerDistributionPanel(SensorBase):
             :param module: CAN ID of the PDP
             :type module: int
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.module = module
         SensorBase.checkPDPModule(module)
         hal.initializePDP(module)

--- a/wpilib/wpilib/pwm.py
+++ b/wpilib/wpilib/pwm.py
@@ -52,6 +52,7 @@ class PWM(SendableBase):
       controllers. Due to the shipping firmware on the Jaguar, we can't run the
       update period less than 5.05 ms.
     """
+
     class PeriodMultiplier:
         """Represents the amount to multiply the minimum servo-pulse pwm
         period by.
@@ -72,7 +73,7 @@ class PWM(SendableBase):
         :param channel: The PWM channel number. 0-9 are on-board, 10-19 are on the MXP port
         :type channel: int
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         SensorBase.checkPWMChannel(channel)
         self.channel = channel
         
@@ -88,7 +89,6 @@ class PWM(SendableBase):
                 
         # Python-specific: Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
-        
     
     @property
     def handle(self):

--- a/wpilib/wpilib/relay.py
+++ b/wpilib/wpilib/relay.py
@@ -89,7 +89,7 @@ class Relay(SendableBase, MotorSafety):
             If not specified, defaults to allowing both directions.
         :type  direction: :class:`Relay.Direction`
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         if direction is None:
             direction = self.Direction.kBoth
         self.channel = channel

--- a/wpilib/wpilib/solenoidbase.py
+++ b/wpilib/wpilib/solenoidbase.py
@@ -21,7 +21,7 @@ class SolenoidBase(SendableBase):
 
         :param moduleNumber: The PCM CAN ID
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         self.moduleNumber = moduleNumber
 
     def getAll(moduleNumber):

--- a/wpilib/wpilib/speedcontrollergroup.py
+++ b/wpilib/wpilib/speedcontrollergroup.py
@@ -23,7 +23,7 @@ class SpeedControllerGroup(SendableBase, SpeedController):
         :param args: SpeedControllers to add
         :type args: :class:`.SpeedController`
         """
-        SendableBase.__init__(self)
+        SendableBase.__init__(self, addLiveWindow=False)
         SpeedController.__init__(self)
 
         self.speedControllers = [speedController] + list(args)

--- a/wpilib/wpilib/ultrasonic.py
+++ b/wpilib/wpilib/ultrasonic.py
@@ -106,7 +106,7 @@ class Ultrasonic(SensorBase):
             trip time of the ping, and the distance.
         :param units: The units returned in either kInches or kMillimeters
         """
-        super().__init__()
+        super().__init__(addLiveWindow=False)
         # Convert to DigitalInput and DigitalOutput if necessary
         self.pingAllocated = False
         self.echoAllocated = False


### PR DESCRIPTION
None of these classes actually call the SendableBase constructor
upstream, so none of these are actually automatically added to
LiveWindow.