### PR TITLE
Update git-source-track metadata for beta

### DIFF
--- a/.gittrack
+++ b/.gittrack
@@ -2,5 +2,5 @@
 validation_root = wpilib/wpilib
 exclude_commits_file = devtools/exclude_commits
 upstream_root = ../allwpilib/wpilibj/src/main/java
-upstream_commit = c8482cd6d2977770848f8b367695a7453f07a587
+upstream_commit = 0a2ab4f0d7823614f8a0b4ec1a06830a0560212c
 

--- a/devtools/exclude_commits
+++ b/devtools/exclude_commits
@@ -15,3 +15,4 @@ eedb8910c36b732f7294886921b8d5d72847041b # wpilibj styleguide beginning newline
 adb6098353b2e4a7f8d2cb8e78d6587b138f8646 # styleguide remove extra newlines
 e548a5f7054ccc221ede1917bb62f512d1fb0fe3 # PMD 6.3.0
 40cc743cc7666e9558f1ac5e7263906e37b8a119 # checkstyle 8.10
+337e89cf6e791d67f6e80fbba8c613cc98d2a36a # Java simulation API

--- a/wpilib/wpilib/analoginput.py
+++ b/wpilib/wpilib/analoginput.py
@@ -329,6 +329,3 @@ class AnalogInput(SendableBase):
     def initSendable(self, builder):
         builder.setSmartDashboardType("Analog Input")
         builder.addDoubleProperty("Value", self.getAverageVoltage, None)
-
-    def getSimObject(self):
-        return AnalogInSim(self.channel)

--- a/wpilib/wpilib/analogoutput.py
+++ b/wpilib/wpilib/analogoutput.py
@@ -72,6 +72,3 @@ class AnalogOutput(SendableBase):
     def initSendable(self, builder):
         builder.setSmartDashboardType("Analog Output")
         builder.addDoubleProperty("Value", self.getVoltage, self.setVoltage)
-
-    def getSimObject(self):
-        return AnalogOutputSim(self.channel)


### PR DESCRIPTION
- Ignore the Java simulation API stuff
- Bump gittrack to track one commit ahead of v2019.1.1-beta-1.