### PR TITLE
Fix Watchdog resetting expiration flag on disable

### DIFF
--- a/.gittrack
+++ b/.gittrack
@@ -2,5 +2,5 @@
 validation_root = wpilib/wpilib
 exclude_commits_file = devtools/exclude_commits
 upstream_root = ../allwpilib/wpilibj/src/main/java
-upstream_commit = 88a09dd13ab01f2a6f3443f6488f4c3ac39531ef
+upstream_commit = 43696956d20ba389d855069ce2e84d779efcc296
 

--- a/wpilib/wpilib/watchdog.py
+++ b/wpilib/wpilib/watchdog.py
@@ -1,4 +1,4 @@
-# validated: 2019-01-30 DV f121ccff0dfb edu/wpi/first/wpilibj/Watchdog.java
+# validated: 2019-02-02 DV 43696956d20b edu/wpi/first/wpilibj/Watchdog.java
 # ----------------------------------------------------------------------------
 # Copyright (c) 2018 FIRST. All Rights Reserved.
 # Open Source Software - may be modified and shared by FRC teams. The code
@@ -190,8 +190,6 @@ class Watchdog:
     def disable(self) -> None:
         """Disables the watchdog timer."""
         with self._queueMutex:
-            self._isExpired = False
-
             watchdogs = self._watchdogs
             try:
                 watchdogs.remove(self)


### PR DESCRIPTION
Resetting the flag should only occur in enable() and reset().
IterativeRobotBase needs the flag to remain set to print epochs after
disabling the Watchdog.