### PR TITLE
Allow sendable chooser to respond to local NT changes

### DIFF
--- a/wpilib/tests/test_sendablechooser.py
+++ b/wpilib/tests/test_sendablechooser.py
@@ -1,0 +1,29 @@
+def test_chooser_control(wpilib, networktables):
+    """
+        Integration test to ensure that we don't accidentally break
+        the chooser control used by various testing infrastructure
+    """
+
+    import networktables.util
+
+    k1 = object()
+    k2 = object()
+
+    chooser = wpilib.SendableChooser()
+    chooser.addOption("k1", k1)
+    chooser.setDefaultOption("k2", k2)
+
+    assert chooser.getSelected() is k2
+
+    wpilib.SmartDashboard.putData("testc", chooser)
+
+    control = networktables.util.ChooserControl("testc")
+    assert control.getSelected() == "k2"
+
+    control.setSelected("k1")
+    networktables.NetworkTables.waitForEntryListenerQueue(5)
+    assert chooser.getSelected() is k1
+
+    control.setSelected("kX")
+    networktables.NetworkTables.waitForEntryListenerQueue(5)
+    assert chooser.getSelected() is None

--- a/wpilib/wpilib/sendablechooser.py
+++ b/wpilib/wpilib/sendablechooser.py
@@ -162,6 +162,7 @@ class SendableChooser(SendableBase):
                 for entry in self.activeEntries:
                     entry.setString(val)
 
+        # python-specific: set local=True
         builder.addStringProperty(
-            SendableChooser.SELECTED, None, _selected_property_setter
+            SendableChooser.SELECTED, None, _selected_property_setter, local=True
         )


### PR DESCRIPTION
- Adds python-specific API to SendableBuilder
- Fixes https://github.com/robotpy/pyfrc/issues/155
- Fixes https://github.com/robotpy/robotpy-wpilib-utilities/issues/129