### PR TITLE
Micro-optimization for _STATUSFUNC

### DIFF
--- a/hal-base/hal/functions.py
+++ b/hal-base/hal/functions.py
@@ -58,8 +58,12 @@ def _STATUSFUNC(name, restype, *params, out=None, library=_dll,
     realparams.append(("status", C.POINTER(C.c_int32)))
     _inner = _inner_func(name, restype, *realparams, out=out, library=library,
                         errcheck=errcheck, handle_missing=handle_missing, c_name=None)
+
+    # micro-optimization: don't lookup C global each time function is called
+    # .. timeit says this saves 2us
+    c_int32 = C.c_int32
     def outer(*args, **kwargs):
-        status = C.c_int32(0)
+        status = c_int32(0)
         rv = _inner(*args, status=status, **kwargs)
         if status.value == 0:
             return rv


### PR DESCRIPTION
Without this:

```
admin@roboRIO-2423-FRC:~# python3 -m timeit -s 'import hal' 'hal.getFPGATime()'
10000 loops, best of 5: 29 usec per loop
```

With this:

```
admin@roboRIO-2423-FRC:~# python3 -m timeit -s 'import hal' 'hal.getFPGATime()'
10000 loops, best of 5: 27.6 usec per loop
```