### PR TITLE
update max number of encoders available in hal-sim

### DIFF
--- a/hal-sim/hal_impl/data.py
+++ b/hal-sim/hal_impl/data.py
@@ -340,7 +340,7 @@ def _reset_hal_data(current_hooks):
             'rate':               OUT(0),
             'min_rate':           OUT(0),
 
-        } for _ in range(13)],
+        } for _ in range(8)],
 
         # There is a lot of config involved here...
         'counter': [{

--- a/hal-sim/hal_impl/data.py
+++ b/hal-sim/hal_impl/data.py
@@ -340,7 +340,7 @@ def _reset_hal_data(current_hooks):
             'rate':               OUT(0),
             'min_rate':           OUT(0),
 
-        } for _ in range(4)],
+        } for _ in range(13)],
 
         # There is a lot of config involved here...
         'counter': [{


### PR DESCRIPTION
Limiting the number of encoders to the number of labeled DIO ports on the RIO divided by 2 causes failure when tests run using hal-sim

I believe the max number of encoders is number of DIO divided by 2, so this commit allows up to 13 encoders before an error is raised.