### PR TITLE
Optimization: remove property indirection for HAL handles

### DIFF
--- a/hal-sim/hal_impl/functions.py
+++ b/hal-sim/hal_impl/functions.py
@@ -2128,8 +2128,6 @@ def setRelay(relayPortHandle, on, status):
 
 def getRelay(relayPortHandle, status):
     status.value = 0
-    if not relayPortHandle:
-        return False
     channel, fwd = _handle_to_channel(relayPortHandle)
     if fwd:
         return hal_data["relay"][channel]["fwd"]

--- a/wpilib/tests/test_counter.py
+++ b/wpilib/tests/test_counter.py
@@ -134,7 +134,7 @@ def test_counter_clear_up_source(wpilib, hal_data):
     check_init(hal_data, 0, 0, 0, (False, False), (False, False))
 
 
-def test_counter_close(wpilib, hal_data):
+def test_counter_close(hal, wpilib, hal_data):
     assert not hal_data["counter"][0]["initialized"]
     assert not hal_data["dio"][0]["initialized"]
     assert not hal_data["dio"][1]["initialized"]
@@ -145,8 +145,8 @@ def test_counter_close(wpilib, hal_data):
     assert hal_data["dio"][0]["initialized"]
     assert hal_data["dio"][1]["initialized"]
     ctr.close()
-    with pytest.raises(ValueError):
-        _ = ctr.counter
+    with pytest.raises(hal.HALError):
+        ctr.get()
     assert not hal_data["counter"][0]["initialized"]
     assert not hal_data["dio"][0]["initialized"]
     assert not hal_data["dio"][1]["initialized"]

--- a/wpilib/tests/test_i2c.py
+++ b/wpilib/tests/test_i2c.py
@@ -39,7 +39,7 @@ class I2CSimulator(I2CSimBase):
         self.closed = port
 
 
-def test_i2c(wpilib):
+def test_i2c(hal, wpilib):
 
     sim = I2CSimulator()
     port = wpilib.I2C.Port.kMXP
@@ -63,5 +63,5 @@ def test_i2c(wpilib):
     i2c.close()
     assert sim.closed == port
 
-    with pytest.raises(ValueError):
-        i2c.port
+    with pytest.raises(hal.HALError):
+        i2c.readOnly(7)

--- a/wpilib/tests/test_pwm.py
+++ b/wpilib/tests/test_pwm.py
@@ -48,12 +48,11 @@ def test_pwm_create_all(wpilib):
         pwms.append(wpilib.PWM(i))
 
 
-def test_pwm_close(pwm, pwm_data, wpilib):
-    assert pwm.handle == pwm._handle
+def test_pwm_close(pwm, pwm_data, wpilib, hal):
     pwm.close()
 
-    with pytest.raises(ValueError):
-        _ = pwm.handle
+    with pytest.raises(hal.HALError):
+        pwm.getSpeed()
 
     assert pwm_data["initialized"] == False
 
@@ -103,9 +102,9 @@ def test_pwm_setRaw(pwm, pwm_data):
     assert pwm_data["raw_value"] == 60
 
 
-def test_pwm_setRaw_freed(pwm, pwm_data):
+def test_pwm_setRaw_freed(hal, pwm, pwm_data):
     pwm.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         pwm.setRaw(60)
     assert pwm_data["raw_value"] == 0
 
@@ -115,9 +114,9 @@ def test_pwm_getRaw(pwm, pwm_data):
     assert pwm.getRaw() == 1234
 
 
-def test_pwm_getRaw_freed(pwm):
+def test_pwm_getRaw_freed(hal, pwm):
     pwm.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         pwm.getRaw()
 
 
@@ -127,9 +126,9 @@ def test_pwm_setPeriodMultiplier(param, expected, pwm, pwm_data):
     assert pwm_data["period_scale"] == expected
 
 
-def test_pwm_setPeriodMultiplier_freed(pwm, pwm_data):
+def test_pwm_setPeriodMultiplier_freed(hal, pwm, pwm_data):
     pwm.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         pwm.setPeriodMultiplier(pwm.PeriodMultiplier.k4X)
     assert pwm_data["period_scale"] is None
 
@@ -145,8 +144,8 @@ def test_pwm_setZeroLatch(pwm, pwm_data):
     assert pwm_data["zero_latch"] == True
 
 
-def test_pwm_setZeroLatch_freed(pwm, pwm_data):
+def test_pwm_setZeroLatch_freed(hal, pwm, pwm_data):
     pwm.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         pwm.setZeroLatch()
     assert pwm_data["zero_latch"] == False

--- a/wpilib/tests/test_relay.py
+++ b/wpilib/tests/test_relay.py
@@ -97,15 +97,12 @@ def test_relay_create_error(hal, wpilib):
 
 def test_relay_close(relay, hal, wpilib):
     # wasport = relay._port
-    assert relay.forwardHandle == relay._forwardHandle
-    assert relay.reverseHandle == relay._reverseHandle
+    # assert relay.forwardHandle == relay._forwardHandle
+    # assert relay.reverseHandle == relay._reverseHandle
 
     relay.close()
-
-    with pytest.raises(ValueError):
-        _ = relay.forwardHandle
-    with pytest.raises(ValueError):
-        _ = relay.reverseHandle
+    assert relay.forwardHandle is None
+    assert relay.reverseHandle is None
 
     # hal.setRelayForward.assert_called_once_with(wasport, False)
     # hal.setRelayReverse.assert_called_once_with(wasport, False)
@@ -152,10 +149,10 @@ def test_relay_set_badvalue(relay):
     # assert not hal.setRelayForward.called and not hal.setRelayReverse.called
 
 
-def test_relay_set_freed(relay):
+def test_relay_set_freed(hal, relay):
     relay.close()
     # hal.reset_mock()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         relay.set(relay.Value.kOff)
     # assert not hal.setRelayForward.called and not hal.setRelayReverse.called
 
@@ -190,10 +187,10 @@ def test_relay_get(dir, value, fwd, rev, wpilib, relay_data):
     # hal.getRelayReverse.assert_called_once_with(relay._port)
 
 
-def test_relay_get_freed(relay, hal):
+def test_relay_get_freed(hal, relay):
     relay.close()
     # hal.reset_mock()
-    with pytest.raises(ValueError):
+    with pytest.raises(hal.HALError):
         relay.get()
     # assert not hal.setRelayForward.called and not hal.setRelayReverse.called
 

--- a/wpilib/tests/test_solenoid.py
+++ b/wpilib/tests/test_solenoid.py
@@ -112,7 +112,7 @@ def test_solenoid(wpilib, hal, hal_data):
 
             s.close()
 
-            with pytest.raises(ValueError):
+            with pytest.raises(hal.HALError):
                 s.set(True)
 
 

--- a/wpilib/tests/test_spi.py
+++ b/wpilib/tests/test_spi.py
@@ -80,9 +80,6 @@ def test_spi(wpilib, monkeypatch):
     spi.close()
     assert sim.closed == True
 
-    with pytest.raises(ValueError):
-        spi.port
-
 
 def test_adxrs450(wpilib, hal_data, monkeypatch, sim_hooks):
 

--- a/wpilib/wpilib/analoginput.py
+++ b/wpilib/wpilib/analoginput.py
@@ -61,18 +61,12 @@ class AnalogInput(SendableBase):
         self.pidSource = self.PIDSourceType.kDisplacement
 
         port = hal.getPort(channel)
-        self._port = hal.initializeAnalogInputPort(port)
+        self.port = hal.initializeAnalogInputPort(port)
 
         hal.report(hal.UsageReporting.kResourceType_AnalogChannel, channel)
         self.setName("AnalogInput", self.channel)
 
-        self.__finalizer = weakref.finalize(self, _freeAnalogInput, self._port)
-
-    @property
-    def port(self):
-        if not self.__finalizer.alive:
-            return None
-        return self._port
+        self.__finalizer = weakref.finalize(self, _freeAnalogInput, self.port)
 
     def close(self) -> None:
         """ Channel destructor """
@@ -83,6 +77,7 @@ class AnalogInput(SendableBase):
         self.__finalizer()
         self.channel = None
         self.accumulatorOffset = 0
+        self.port = None
 
     def getValue(self) -> int:
         """Get a sample straight from this channel. The sample is a 12-bit

--- a/wpilib/wpilib/analogoutput.py
+++ b/wpilib/wpilib/analogoutput.py
@@ -37,18 +37,12 @@ class AnalogOutput(SendableBase):
         self.channel = channel
 
         port = hal.getPort(channel)
-        self._port = hal.initializeAnalogOutputPort(port)
+        self.port = hal.initializeAnalogOutputPort(port)
 
         self.setName("AnalogOutput", channel)
         hal.report(hal.UsageReporting.kResourceType_AnalogChannel, channel, 1)
 
-        self.__finalizer = weakref.finalize(self, _freeAnalogOutput, self._port)
-
-    @property
-    def port(self):
-        if not self.__finalizer.alive:
-            return None
-        return self._port
+        self.__finalizer = weakref.finalize(self, _freeAnalogOutput, self.port)
 
     def close(self) -> None:
         """Channel destructor.
@@ -59,6 +53,7 @@ class AnalogOutput(SendableBase):
         AnalogOutput.channels.free(self.channel)
         self.__finalizer()
         self.channel = None
+        self.port = None
 
     def getChannel(self) -> int:
         """Get the channel of this AnalogOutput.

--- a/wpilib/wpilib/analogtrigger.py
+++ b/wpilib/wpilib/analogtrigger.py
@@ -56,8 +56,8 @@ class AnalogTrigger(SendableBase):
         else:
             self.analogInput = channel
 
-        self._port, self.index = hal.initializeAnalogTrigger(self.analogInput.port)
-        self.__finalizer = weakref.finalize(self, _freeAnalogTrigger, self._port)
+        self.port, self.index = hal.initializeAnalogTrigger(self.analogInput.port)
+        self.__finalizer = weakref.finalize(self, _freeAnalogTrigger, self.port)
 
         # Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
@@ -66,16 +66,11 @@ class AnalogTrigger(SendableBase):
 
         self.setName("AnalogTrigger", self.analogInput.getChannel())
 
-    @property
-    def port(self):
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use AnalogTrigger after close() has been called")
-        return self._port
-
     def close(self) -> None:
         """Release the resources used by this object"""
         super().close()
         self.__finalizer()
+        self.port = None
         if self.analogInput:
             self.analogInput.close()
 

--- a/wpilib/wpilib/counter.py
+++ b/wpilib/wpilib/counter.py
@@ -22,16 +22,16 @@ __all__ = ["Counter"]
 
 
 def _freeCounter(counterObj: "Counter") -> None:
-    hal.setCounterUpdateWhenEmpty(counterObj._counter, True)
+    hal.setCounterUpdateWhenEmpty(counterObj.counter, True)
 
     counterObj.clearUpSource()
     counterObj.clearDownSource()
 
-    hal.freeCounter(counterObj._counter)
+    hal.freeCounter(counterObj.counter)
 
     counterObj.upSource = None
     counterObj.downSource = None
-    counterObj._counter = None
+    counterObj.counter = None
 
 
 class Counter(SendableBase):
@@ -155,7 +155,7 @@ class Counter(SendableBase):
         self.pidSource = self.PIDSourceType.kDisplacement
 
         # create counter
-        self._counter, self.index = hal.initializeCounter(mode)
+        self.counter, self.index = hal.initializeCounter(mode)
         self.__finalizer = weakref.finalize(self, _freeCounter, self)
 
         self.setMaxPeriod(0.5)
@@ -178,21 +178,16 @@ class Counter(SendableBase):
         if upSource is not None and downSource is not None:
             if encodingType == self.EncodingType.k1X:
                 self.setUpSourceEdge(True, False)
-                hal.setCounterAverageSize(self._counter, 1)
+                hal.setCounterAverageSize(self.counter, 1)
             else:
                 self.setUpSourceEdge(True, True)
-                hal.setCounterAverageSize(self._counter, 2)
+                hal.setCounterAverageSize(self.counter, 2)
             self.setDownSourceEdge(inverted, True)
-
-    @property
-    def counter(self):
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use counter after close() has been called")
-        return self._counter
 
     def close(self) -> None:
         super().close()
         self.__finalizer()
+        self.counter = None
 
     def getFPGAIndex(self) -> int:
         """
@@ -291,7 +286,7 @@ class Counter(SendableBase):
             self.upSource.close()
             self.allocatedUpSource = False
         self.upSource = None
-        hal.clearCounterUpSource(self._counter)
+        hal.clearCounterUpSource(self.counter)
 
     def setDownSource(self, *args, **kwargs) -> None:
         """Set the down counting source for the counter.
@@ -387,7 +382,7 @@ class Counter(SendableBase):
             self.allocatedDownSource = False
         self.downSource = None
 
-        hal.clearCounterDownSource(self._counter)
+        hal.clearCounterDownSource(self.counter)
 
     def setUpDownCounterMode(self) -> None:
         """Set standard up / down counting mode on this counter. Up and down

--- a/wpilib/wpilib/digitaloutput.py
+++ b/wpilib/wpilib/digitaloutput.py
@@ -42,7 +42,7 @@ class DigitalOutput(SendableBase):
         """
 
         super().__init__()
-        self._pwmGenerator = None
+        self.pwmGenerator = None
         self._pwmGenerator_finalizer = None
 
         SensorUtil.checkDigitalChannel(channel)
@@ -53,21 +53,13 @@ class DigitalOutput(SendableBase):
         hal.report(hal.UsageReporting.kResourceType_DigitalOutput, channel)
         self.setName("DigitalOutput", channel)
 
-    @property
-    def pwmGenerator(self) -> Optional[int]:
-        if self._pwmGenerator_finalizer is None:
-            return None
-        if not self._pwmGenerator_finalizer.alive:
-            return None
-        return self._pwmGenerator
-
     def close(self) -> None:
         """Free the resources associated with a digital output."""
         super().close()
         # finalize the pwm only if we have allocated it
         if self.pwmGenerator is not None:
             self._pwmGenerator_finalizer()
-        self._pwmGenerator = None
+        self.pwmGenerator = None
         if self.pwmGenerator is not self.invalidPwmGenerator:
             self.disablePWM()
         hal.freeDIOPort(self.handle)
@@ -134,11 +126,11 @@ class DigitalOutput(SendableBase):
         """
         if self.pwmGenerator is not self.invalidPwmGenerator:
             return
-        self._pwmGenerator = hal.allocateDigitalPWM()
-        hal.setDigitalPWMDutyCycle(self._pwmGenerator, initialDutyCycle)
-        hal.setDigitalPWMOutputChannel(self._pwmGenerator, self.channel)
+        self.pwmGenerator = hal.allocateDigitalPWM()
+        hal.setDigitalPWMDutyCycle(self.pwmGenerator, initialDutyCycle)
+        hal.setDigitalPWMOutputChannel(self.pwmGenerator, self.channel)
         self._pwmGenerator_finalizer = weakref.finalize(
-            self, _freePWMGenerator, self._pwmGenerator
+            self, _freePWMGenerator, self.pwmGenerator
         )
 
     def disablePWM(self) -> None:
@@ -149,8 +141,8 @@ class DigitalOutput(SendableBase):
         """
         if self.pwmGenerator is not self.invalidPwmGenerator:
             return
-        hal.setDigitalPWMOutputChannel(self._pwmGenerator, SensorUtil.kDigitalChannels)
-        hal.freeDigitalPWM(self._pwmGenerator)
+        hal.setDigitalPWMOutputChannel(self.pwmGenerator, SensorUtil.kDigitalChannels)
+        hal.freeDigitalPWM(self.pwmGenerator)
         self._pwmGenerator_finalizer()
 
     def updateDutyCycle(self, dutyCycle: float) -> None:
@@ -163,7 +155,7 @@ class DigitalOutput(SendableBase):
         """
         if self.pwmGenerator is self.invalidPwmGenerator:
             return
-        hal.setDigitalPWMDutyCycle(self._pwmGenerator, dutyCycle)
+        hal.setDigitalPWMDutyCycle(self.pwmGenerator, dutyCycle)
 
     def initSendable(self, builder: SendableBuilder) -> None:
         builder.setSmartDashboardType("Digital Output")

--- a/wpilib/wpilib/encoder.py
+++ b/wpilib/wpilib/encoder.py
@@ -186,13 +186,13 @@ class Encoder(SendableBase):
         self.indexSource = indexSource
         self.encodingType = encodingType
         self.pidSource = self.PIDSourceType.kDisplacement
-        self._encoder = None
+        self.encoder = None
         self.counter = None
         self.speedEntry = None
         self.distanceEntry = None
         self.distancePerTickEntry = None
 
-        self._encoder = hal.initializeEncoder(
+        self.encoder = hal.initializeEncoder(
             aSource.getPortHandleForRouting(),
             aSource.getAnalogTriggerTypeForRouting(),
             bSource.getPortHandleForRouting(),
@@ -201,7 +201,7 @@ class Encoder(SendableBase):
             encodingType,
         )
 
-        self.__finalizer = weakref.finalize(self, _freeEncoder, self._encoder)
+        self.__finalizer = weakref.finalize(self, _freeEncoder, self.encoder)
 
         # Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
@@ -212,12 +212,6 @@ class Encoder(SendableBase):
         self.index = self.getFPGAIndex()
         hal.report(hal.UsageReporting.kResourceType_Encoder, self.index, encodingType)
         self.setName("Encoder", self.index)
-
-    @property
-    def encoder(self):
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use encoder after free() has been called")
-        return self._encoder
 
     def getFPGAIndex(self) -> int:
         """
@@ -250,7 +244,7 @@ class Encoder(SendableBase):
         self.bSource = None
         self.indexSource = None
         self.__finalizer()
-        self._encoder = None
+        self.encoder = None
 
     def getRaw(self) -> int:
         """Gets the raw value from the encoder. The raw value is the actual

--- a/wpilib/wpilib/i2c.py
+++ b/wpilib/wpilib/i2c.py
@@ -63,22 +63,16 @@ class I2C:
             assert hasattr(simPort, "initializeI2C")
             assert hasattr(simPort, "closeI2C")
 
-            self._port = (simPort, port)
+            self.port = (simPort, port)
         else:
-            self._port = port
+            self.port = port
 
         self.deviceAddress = deviceAddress
 
-        hal.initializeI2C(self._port)
-        self.__finalizer = weakref.finalize(self, _freeI2C, self._port)
+        hal.initializeI2C(self.port)
+        self.__finalizer = weakref.finalize(self, _freeI2C, self.port)
 
         hal.report(hal.UsageReporting.kResourceType_I2C, deviceAddress)
-
-    @property
-    def port(self):
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use i2c port after free() has been called")
-        return self._port
 
     def free(self) -> None:
         """
@@ -90,6 +84,7 @@ class I2C:
 
     def close(self) -> None:
         self.__finalizer()
+        self.port = None
 
     def transaction(
         self, dataToSend: Union[bytes, List[int]], receiveSize: int

--- a/wpilib/wpilib/interruptablesensorbase.py
+++ b/wpilib/wpilib/interruptablesensorbase.py
@@ -28,18 +28,10 @@ class InterruptableSensorBase(SendableBase):
         """Create a new InterrupatableSensorBase"""
         super().__init__()
         # The interrupt resource
-        self._interrupt = None
+        self.interrupt = None
         self._interrupt_finalizer = None
         # Flags if the interrupt being allocated is synchronous
         self.isSynchronousInterrupt = False
-
-    @property
-    def interrupt(self) -> Optional[hal.InterruptHandle]:
-        if self._interrupt_finalizer is None:
-            return None
-        if not self._interrupt_finalizer.alive:
-            return None
-        return self._interrupt
 
     def close(self) -> None:
         super().close()
@@ -90,9 +82,9 @@ class InterruptableSensorBase(SendableBase):
         if self.interrupt is not None:
             raise ValueError("The interrupt has already been allocated")
         self.isSynchronousInterrupt = watcher
-        self._interrupt = hal.initializeInterrupts(watcher)
+        self.interrupt = hal.initializeInterrupts(watcher)
         self._interrupt_finalizer = weakref.finalize(
-            self, hal.cleanInterrupts, self._interrupt
+            self, hal.cleanInterrupts, self.interrupt
         )
 
     def cancelInterrupts(self) -> None:

--- a/wpilib/wpilib/pwm.py
+++ b/wpilib/wpilib/pwm.py
@@ -84,8 +84,8 @@ class PWM(MotorSafety, SendableBase):
         SensorUtil.checkPWMChannel(channel)
         self.channel = channel
 
-        self._handle = hal.initializePWMPort(hal.getPort(channel))
-        self.__finalizer = weakref.finalize(self, _freePWM, self._handle)
+        self.handle = hal.initializePWMPort(hal.getPort(channel))
+        self.__finalizer = weakref.finalize(self, _freePWM, self.handle)
 
         self.setDisabled()
 
@@ -99,12 +99,6 @@ class PWM(MotorSafety, SendableBase):
         # Python-specific: Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
 
-    @property
-    def handle(self) -> hal.DigitalHandle:
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use channel after free() has been called")
-        return self._handle
-
     def close(self) -> None:
         """Free the PWM channel.
 
@@ -112,10 +106,10 @@ class PWM(MotorSafety, SendableBase):
         to 0.
         """
         super().close()
-        if self._handle is None:
+        if self.handle is None:
             return
         self.__finalizer()
-        self._handle = None
+        self.handle = None
 
     def stopMotor(self):
         self.setDisabled()

--- a/wpilib/wpilib/serialport.py
+++ b/wpilib/wpilib/serialport.py
@@ -109,12 +109,12 @@ class SerialPort:
                 msg = "Using stub simulator for Serial port %s" % port
                 warnings.warn(msg)
 
-            self._port = (simPort, port)
+            self.port = (simPort, port)
         else:
-            self._port = port
+            self.port = port
 
-        hal.initializeSerialPort(self._port)
-        self.__finalizer = weakref.finalize(self, _freeSerialPort, self._port)
+        hal.initializeSerialPort(self.port)
+        self.__finalizer = weakref.finalize(self, _freeSerialPort, self.port)
 
         hal.setSerialBaudRate(self.port, baudRate)
         hal.setSerialDataBits(self.port, dataBits)
@@ -137,15 +137,10 @@ class SerialPort:
         # Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
 
-    @property
-    def port(self) -> Port:
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use serial port after free() has been called")
-        return self._port
-
     def close(self) -> None:
         """Destructor"""
         self.__finalizer()
+        self.port = None
 
     def setFlowControl(self, flowControl: FlowControl) -> None:
         """Set the type of flow control to enable on this port.

--- a/wpilib/wpilib/solenoid.py
+++ b/wpilib/wpilib/solenoid.py
@@ -80,28 +80,22 @@ class Solenoid(SolenoidBase):
         SensorUtil.checkSolenoidChannel(channel)
 
         portHandle = hal.getPortWithModule(moduleNumber, channel)
-        self._solenoidHandle = hal.initializeSolenoidPort(portHandle)
+        self.solenoidHandle = hal.initializeSolenoidPort(portHandle)
 
         hal.report(hal.UsageReporting.kResourceType_Solenoid, channel, moduleNumber)
         self.setName("Solenoid", self.moduleNumber, self.channel)
 
-        self.__finalizer = weakref.finalize(self, _freeSolenoid, self._solenoidHandle)
+        self.__finalizer = weakref.finalize(self, _freeSolenoid, self.solenoidHandle)
 
         # Need this to free on unit test wpilib reset
         Resource._add_global_resource(self)
-
-    @property
-    def solenoidHandle(self) -> None:
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use channel after close() has been called")
-        return self._solenoidHandle
 
     def close(self) -> None:
         """Mark the solenoid as close."""
         super().close()
 
         self.__finalizer()
-        self._solenoidHandle = None
+        self.solenoidHandle = None
 
     def set(self, on: bool) -> None:
         """Set the value of a solenoid.

--- a/wpilib/wpilib/spi.py
+++ b/wpilib/wpilib/spi.py
@@ -73,9 +73,9 @@ class SPI:
             assert hasattr(simPort, "initializeSPI")
             assert hasattr(simPort, "closeSPI")
 
-            self._port = (simPort, port)
+            self.port = (simPort, port)
         else:
-            self._port = port
+            self.port = port
 
         # python-specific: these are bools instead of integers
         self.msbFirst = False
@@ -84,23 +84,18 @@ class SPI:
 
         self.accum = None
 
-        hal.initializeSPI(self._port)
-        self.__finalizer = weakref.finalize(self, _freeSPI, self._port)
+        hal.initializeSPI(self.port)
+        self.__finalizer = weakref.finalize(self, _freeSPI, self.port)
 
         SPI.devices += 1
         hal.report(hal.UsageReporting.kResourceType_SPI, SPI.devices)
-
-    @property
-    def port(self) -> Port:
-        if not self.__finalizer.alive:
-            raise ValueError("Cannot use SPI after free() has been called")
-        return self._port
 
     def close(self) -> None:
         if self.accum is not None:
             self.accum.close()
             self.accum = None
         self.__finalizer()
+        self.port = None
 
     def setClockRate(self, hz: int) -> None:
         """Configure the rate of the generated clock signal. The default value is 500,000 Hz. The maximum


### PR DESCRIPTION
- They don't provide any value, since an error will be raised by the HAL if an invalid handle is used