### PR TITLE
Control word cache should expire every 50ms, not every 50us

### DIFF
--- a/wpilib/tests/test_driverstation.py
+++ b/wpilib/tests/test_driverstation.py
@@ -259,11 +259,16 @@ def test_isFMSAttached_mock(dsmock, halmock):
     assert not dsmock.isFMSAttached()
 
 
-def test_isFMSAttached(ds, hal_data):
+def test_isFMSAttached(ds, hal_data, sim_hooks):
     hal_data["control"]["fmsAttached"] = True
+    sim_hooks.delaySeconds(0.1)
     assert ds.isFMSAttached()
 
     hal_data["control"]["fmsAttached"] = False
+    assert ds.isFMSAttached()
+    sim_hooks.delaySeconds(0.025)
+    assert ds.isFMSAttached()
+    sim_hooks.delaySeconds(0.03)
     assert not ds.isFMSAttached()
 
 

--- a/wpilib/wpilib/driverstation.py
+++ b/wpilib/wpilib/driverstation.py
@@ -978,6 +978,6 @@ class DriverStation:
         """
         now = hal.getFPGATime()
         with self.controlWordMutex:
-            if (now - self.lastControlWordUpdate) > 50 or force:
+            if (now - self.lastControlWordUpdate) > 50000 or force:
                 hal.getControlWord(self.controlWordCache)
                 self.lastControlWordUpdate = now


### PR DESCRIPTION
This could definitely cause some performance issues -- though it appears there's a cache down in HAL too stopping it from going out to netcomm, so it might not be a huge improvement.