### PR TITLE
Simplify geometry objects

### DIFF
--- a/gen/geometry/Pose2d.yml
+++ b/gen/geometry/Pose2d.yml
@@ -7,6 +7,7 @@ functions:
     ignore: true
 classes:
   Pose2d:
+    shared_ptr: false
     methods:
       Pose2d:
         overloads:

--- a/gen/geometry/Pose2d.yml
+++ b/gen/geometry/Pose2d.yml
@@ -7,7 +7,6 @@ functions:
     ignore: true
 classes:
   Pose2d:
-    shared_ptr: true
     methods:
       Pose2d:
         overloads:

--- a/gen/geometry/Rotation2d.yml
+++ b/gen/geometry/Rotation2d.yml
@@ -7,7 +7,6 @@ functions:
     ignore: true
 classes:
   Rotation2d:
-    shared_ptr: true
     methods:
       Rotation2d:
         overloads:
@@ -33,6 +32,6 @@ classes:
 
 inline_code: |
   cls_Rotation2d
-    .def_static("fromDegrees", [](units::degree_t value) {
-      return std::make_shared<Rotation2d>(value);
+    .def_static("fromDegrees", [](double value) {
+      return Rotation2d{units::degree_t(value)};
     });

--- a/gen/geometry/Rotation2d.yml
+++ b/gen/geometry/Rotation2d.yml
@@ -7,6 +7,7 @@ functions:
     ignore: true
 classes:
   Rotation2d:
+    shared_ptr: false
     methods:
       Rotation2d:
         overloads:

--- a/gen/geometry/Rotation2d.yml
+++ b/gen/geometry/Rotation2d.yml
@@ -34,4 +34,7 @@ inline_code: |
   cls_Rotation2d
     .def_static("fromDegrees", [](double value) {
       return Rotation2d{units::degree_t(value)};
+    })
+    .def("__repr__", [](Rotation2d *self) {
+      return "Rotation2d(" + std::to_string(self->Radians()()) + ")";
     });

--- a/gen/geometry/Transform2d.yml
+++ b/gen/geometry/Transform2d.yml
@@ -5,6 +5,7 @@ extra_includes:
 
 classes:
   Transform2d:
+    shared_ptr: false
     methods:
       Transform2d:
         overloads:

--- a/gen/geometry/Transform2d.yml
+++ b/gen/geometry/Transform2d.yml
@@ -5,7 +5,6 @@ extra_includes:
 
 classes:
   Transform2d:
-    shared_ptr: true
     methods:
       Transform2d:
         overloads:

--- a/gen/geometry/Translation2d.yml
+++ b/gen/geometry/Translation2d.yml
@@ -7,7 +7,6 @@ functions:
     ignore: true
 classes:
   Translation2d:
-    shared_ptr: true
     methods:
       Translation2d:
         overloads:

--- a/gen/geometry/Translation2d.yml
+++ b/gen/geometry/Translation2d.yml
@@ -7,6 +7,7 @@ functions:
     ignore: true
 classes:
   Translation2d:
+    shared_ptr: false
     methods:
       Translation2d:
         overloads:

--- a/gen/geometry/Twist2d.yml
+++ b/gen/geometry/Twist2d.yml
@@ -2,7 +2,6 @@
 
 classes:
   Twist2d:
-    shared_ptr: true
     attributes:
       dx:
       dy:

--- a/gen/geometry/Twist2d.yml
+++ b/gen/geometry/Twist2d.yml
@@ -2,6 +2,7 @@
 
 classes:
   Twist2d:
+    shared_ptr: false
     attributes:
       dx:
       dy:


### PR DESCRIPTION
These are value types which are never passed around through shared_ptr.

Also reduce the redundancy of the signature for Rotation2d.fromDegrees.