### PR TITLE
Document SimpleMotorFeedforwardMeters

### DIFF
--- a/gen/controller/SimpleMotorFeedforward.yml
+++ b/gen/controller/SimpleMotorFeedforward.yml
@@ -30,12 +30,12 @@ templates:
     qualname: frc::SimpleMotorFeedforward
     params:
       - units::dimensionless::scalar
-
-  # TODO: remove for 2021
   SimpleMotorFeedforwardMeters:
     qualname: frc::SimpleMotorFeedforward
     params:
       - units::meter
+
+  # TODO: remove for 2021
   SimpleMotorFeedforwardFeet:
     qualname: frc::SimpleMotorFeedforward
     params:

--- a/wpilib/controller/__init__.py
+++ b/wpilib/controller/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     "ProfiledPIDController",
     "RamseteController",
     "SimpleMotorFeedforward",
+    "SimpleMotorFeedforwardMeters",
 ]


### PR DESCRIPTION
As it turns out, this is used by DifferentialDriveVoltageConstraint.
(It doesn't take SimpleMotorFeedforwardFeet. I checked.)