### PR TITLE
Simplify Pose2d repr

### DIFF
--- a/wpilib/src/rpy/geometryToString.h
+++ b/wpilib/src/rpy/geometryToString.h
@@ -18,8 +18,8 @@ inline std::string toString(const frc::Translation2d& self) {
 
 inline std::string toString(const frc::Pose2d& self) {
   return "Pose2d("
-    "translation=" + rpy::toString(self.Translation()) + ", "
-    "rotation=" + rpy::toString(self.Rotation()) + ")";
+    + rpy::toString(self.Translation()) + ", "
+    + rpy::toString(self.Rotation()) + ")";
 }
 
 }  // namespace rpy


### PR DESCRIPTION
It's already obvious that each part is the translation and rotation component.

This matches up closer with the Java version.