### PR TITLE
Fix geometry/kinematics reprs

### DIFF
--- a/gen/kinematics/ChassisSpeeds.yml
+++ b/gen/kinematics/ChassisSpeeds.yml
@@ -48,8 +48,8 @@ inline_code: |
       }
     )
     .def("__repr__", [](const ChassisSpeeds &cs) -> std::string {
-      return "ChassisSpeeds(vx=" + std::to_string(cs.vx()) + "m/s, "
-                           "vy=" + std::to_string(cs.vy()) + "m/s, "
-                           "omega=" + std::to_string(cs.omega()) + "rad/s)";
+      return "ChassisSpeeds(vx=" + std::to_string(cs.vx()) + ", "
+                           "vy=" + std::to_string(cs.vy()) + ", "
+                           "omega=" + std::to_string(cs.omega()) + ")";
     })
   ;

--- a/gen/kinematics/DifferentialDriveWheelSpeeds.yml
+++ b/gen/kinematics/DifferentialDriveWheelSpeeds.yml
@@ -37,8 +37,8 @@ inline_code: |
       }
     )
     .def("__repr__", [](const DifferentialDriveWheelSpeeds &dds) -> std::string {
-      return "DifferentialDriveWheelSpeeds(left=" + std::to_string(dds.left()) + "m/s, "
-                                          "right=" + std::to_string(dds.right()) + "m/s)";
+      return "DifferentialDriveWheelSpeeds(left=" + std::to_string(dds.left()) + ", "
+                                          "right=" + std::to_string(dds.right()) + ")";
     })
   ;
 

--- a/gen/kinematics/SwerveModuleState.yml
+++ b/gen/kinematics/SwerveModuleState.yml
@@ -25,7 +25,7 @@ inline_code: |
       }
     )
     .def("__repr__", [](const SwerveModuleState &ss) -> std::string {
-      return "SwerveModuleState(speed=" + std::to_string(ss.speed()) + "m/s, "
-                               "angle=" + std::to_string(ss.angle.Radians()()) + "rad)";
+      return "SwerveModuleState(speed=" + std::to_string(ss.speed()) + ", "
+                               "angle=" + std::to_string(ss.angle.Radians()()) + ")";
     })
   ;

--- a/wpilib/src/rpy/geometryToString.h
+++ b/wpilib/src/rpy/geometryToString.h
@@ -9,13 +9,13 @@ namespace rpy {
 
 
 inline std::string toString(const frc::Rotation2d& self) {
-  return "Rotation2d(" + std::to_string(self.Radians()()) + "rad)";
+  return "Rotation2d(" + std::to_string(self.Radians()()) + ")";
 }
 
 inline std::string toString(const frc::Translation2d& self) {
   return "Translation2d("
-    "x=" + std::to_string(self.X()()) + "m, "
-    "y=" + std::to_string(self.Y()()) + "m)";
+    "x=" + std::to_string(self.X()()) + ", "
+    "y=" + std::to_string(self.Y()()) + ")";
 }
 
 inline std::string toString(const frc::Transform2d& self) {


### PR DESCRIPTION
[From the Python documentation for `repr()`](https://docs.python.org/3/library/functions.html#repr):

> For many types, this function makes an attempt to return a string that would yield an object with the same value when passed to `eval()`, otherwise the representation is a string enclosed in angle brackets [...]

This reverts the geometry `__repr__` and fixes the kinematics `__repr__` implementations to adhere to the expected behaviour of `repr()`.