### PR TITLE
Fix empty sendable chooser

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # This file is intended for use on readthedocs
-sphinx
+sphinx != 3.5.0
 sphinx-rtd-theme
 robotpy-sphinx-plugin
--e docs
+# -e docs

--- a/gen/SendableChooser.yml
+++ b/gen/SendableChooser.yml
@@ -15,8 +15,12 @@ classes:
       GetSelected:
         # weirdness because return type
         cpp_code: |
-          [](frc::SendableChooser<T> * __that) {
-            return __that->GetSelected();
+          [](frc::SendableChooser<T> * __that) -> py::object {
+            auto v = __that->GetSelected();
+            if (!v) {
+              return py::none();
+            }
+            return v;
           }
       InitSendable:
 

--- a/tests/test_wpilib.py
+++ b/tests/test_wpilib.py
@@ -1,0 +1,9 @@
+import wpilib
+
+
+def test_sendable_chooser():
+    chooser = wpilib.SendableChooser()
+    assert chooser.getSelected() is None
+
+    chooser.setDefaultOption("option", True)
+    assert chooser.getSelected() is True


### PR DESCRIPTION
Demonstration of prior error:

```
    def test_sendable_chooser():
        chooser = wpilib.SendableChooser()
>       assert chooser.getSelected() is None
E       TypeError: Unable to convert function return value to a Python type! The signature was
E               (self: wpilib._wpilib.SendableChooser) -> object
```