### PR TITLE
Fix license link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation instructions can be found in the [RobotPy documentation](https://ro
 License
 =======
 
-See [LICENSE.txt](wpilib/LICENSE.txt)
+See [LICENSE.txt](LICENSE.txt)
 
 Contributors
 ============


### PR DESCRIPTION
This (tiny) commit fixes the broken link in the README file and fixes #675 