### PR TITLE
Display deploy.json data at robot startup

### DIFF
--- a/wpilib/__init__.py
+++ b/wpilib/__init__.py
@@ -215,6 +215,7 @@ SpeedControllerGroup = MotorControllerGroup
 del _init_wpilib
 
 from .cameraserver import CameraServer
+from .deployinfo import getDeployData
 
 try:
     from .version import version as __version__

--- a/wpilib/_impl/main.py
+++ b/wpilib/_impl/main.py
@@ -13,9 +13,26 @@ from .logconfig import configure_logging
 
 def _log_versions():
     import wpilib
+    import wpilib.deployinfo
     import hal
 
     import logging
+
+    data = wpilib.deployinfo.getDeployData()
+    if data:
+        logger = logging.getLogger("deploy-info")
+        logger.info(
+            "%s@%s at %s",
+            data.get("deploy-user", "<unknown>"),
+            data.get("deploy-host", "<unknown>"),
+            data.get("deploy-date", "<unknown>"),
+        )
+        if "git-hash" in data:
+            logger.info(
+                "- git info: %s (branch=%s)",
+                data.get("git-desc", "<unknown>"),
+                data.get("git-branch", "<unknown>"),
+            )
 
     logger = logging.getLogger("wpilib")
 

--- a/wpilib/deployinfo.py
+++ b/wpilib/deployinfo.py
@@ -1,0 +1,33 @@
+from ._wpilib import RobotBase
+import json
+import typing
+
+
+def getDeployData() -> typing.Union[None, typing.Dict[str, str]]:
+    """
+    Utility function useful for retrieving deploy-related information
+    that pyfrc stores with your robot code. The dictionary has the
+    following keys:
+
+    * deploy-host
+    * deploy-user
+    * deploy-date
+    * code-path
+
+    If the code is deployed from a git repo, and the git program is in
+    your path, the following keys will also be present:
+
+    * git-hash
+    * git-desc
+    * git-branch
+
+    :returns: None in simulation, or a dictionary
+    """
+    if RobotBase.isReal():
+        return None
+
+    try:
+        with open("/home/lvuser/py/deploy.json") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        return {}

--- a/wpilib/deployinfo.py
+++ b/wpilib/deployinfo.py
@@ -3,7 +3,7 @@ import json
 import typing
 
 
-def getDeployData() -> typing.Union[None, typing.Dict[str, str]]:
+def getDeployData() -> typing.Optional[typing.Dict[str, str]]:
     """
     Utility function useful for retrieving deploy-related information
     that pyfrc stores with your robot code. The dictionary has the


### PR DESCRIPTION
Not quite sure if I like the naming or placement of these. Open for bikeshedding. Currently looks like this:

```
02:17:53:468 INFO    : deploy-info         : virtuald@hostname at 2022-03-04T02:04:09
02:17:53:468 INFO    : deploy-info         : - git info: fa1331a-dirty (branch=main)
```