### PR TITLE
Fix DataLogManager.getLog() trying to copy

### DIFF
--- a/gen/DataLogManager.yml
+++ b/gen/DataLogManager.yml
@@ -9,5 +9,6 @@ classes:
       Start:
       Log:
       GetLog:
+        return_value_policy: reference
       GetLogDir:
       LogNetworkTables:

--- a/tests/test_datalogmanager.py
+++ b/tests/test_datalogmanager.py
@@ -1,10 +1,10 @@
-import tempfile
-import pytest
+import pathlib
 import wpilib
 
 
-def test_get_log():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        wpilib.DataLogManager.start(tmpdir)
-        log = wpilib.DataLogManager.getLog()
-        assert log is not None
+def test_get_log(tmp_path: pathlib.Path):
+    log_dir = tmp_path / "wpilogs"
+    log_dir.mkdir()
+    wpilib.DataLogManager.start(str(log_dir))
+    log = wpilib.DataLogManager.getLog()
+    assert log is not None

--- a/tests/test_datalogmanager.py
+++ b/tests/test_datalogmanager.py
@@ -1,0 +1,10 @@
+import tempfile
+import pytest
+import wpilib
+
+
+def test_get_log():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wpilib.DataLogManager.start(tmpdir)
+        log = wpilib.DataLogManager.getLog()
+        assert log is not None


### PR DESCRIPTION
```pytb
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/rpy/lib/python3.10/site-packages/wpilib/_impl/start.py", line 131, in _start
    self.robot.startCompetition()
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magicrobot.py", line 355, in startCompetition
    self.robotInit()
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magicrobot.py", line 98, in robotInit
    self.createObjects()
  File "~/dev/frc/thedropbears/pyrapidreact/robot.py", line 47, in createObjects
    self.data_log = wpilib.DataLogManager.getLog()
RuntimeError: return_value_policy = copy, but type is non-copyable! (compile in debug mode for details)